### PR TITLE
Add the `EnumerateInterfaces` action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [dependencies]
 fleetspeak = { version = "0.1.2" }
 humantime = { version = "2.0.0" }
-ipnetwork = { version = "0.16.0" }
 log = { version = "0.4.8" }
 pnet = { version = "0.26.0" }
 prost = { version = "0.6.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,15 @@ fleetspeak = { version = "0.1.2" }
 humantime = { version = "2.0.0" }
 log = { version = "0.4.8" }
 netstat2 = { version = "0.8.1" }
-pnet = { version = "0.26.0" }
 prost = { version = "0.6.1" }
 prost-types = { version = "0.6.1" }
 rrg-proto = { path = "proto/" }
 simplelog = { version = "0.7.6" }
 structopt = { version = "0.3.12" }
 sysinfo = { version = "0.14.1" }
+
+[target.'cfg(target_family = "unix")'.dependencies]
+pnet = { version = "0.26.0" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 proc-mounts = { version = "0.2.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2018"
 [dependencies]
 fleetspeak = { version = "0.1.1" }
 humantime = { version = "2.0.0" }
+ipnetwork = { version = "0.15.1" }
 log = { version = "0.4.8" }
+pnet = { version = "0.25.0" }
 prost = { version = "0.6.1" }
 prost-types = { version = "0.6.1" }
 rrg-proto = { path = "proto/" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 [dependencies]
 fleetspeak = { version = "0.1.1" }
 humantime = { version = "2.0.0" }
-ipnetwork = { version = "0.15.1" }
+ipnetwork = { version = "0.16.0" }
 log = { version = "0.4.8" }
-pnet = { version = "0.25.0" }
+pnet = { version = "0.26.0" }
 prost = { version = "0.6.1" }
 prost-types = { version = "0.6.1" }
 rrg-proto = { path = "proto/" }

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -8,14 +8,12 @@
 //! The interfaces action lists all network interfaces available for the client,
 //! collecting their names, MAC and IP addresses.
 
-use std::net::IpAddr;
-
 use ipnetwork::IpNetwork;
 use pnet::{
     datalink::{self, NetworkInterface},
     util::MacAddr,
 };
-use rrg_proto::{Interface, NetworkAddress, network_address::Family};
+use rrg_proto::{Interface, NetworkAddress};
 
 use crate::session::{self, Session};
 
@@ -49,13 +47,16 @@ fn mac_to_vec(mac: MacAddr) -> Vec<u8> {
 ///
 /// [ip_network]: ../../../ipnetwork/enum.IpNetwork.html
 fn ip_to_proto(ip_network: IpNetwork) -> NetworkAddress {
+    use rrg_proto::network_address::Family;
+    use std::net::IpAddr::{V4, V6};
+
     match ip_network.ip() {
-        IpAddr::V4(ipv4) => NetworkAddress {
+        V4(ipv4) => NetworkAddress {
             address_type: Some(Family::Inet.into()),
             packed_bytes: Some(ipv4.octets().to_vec()),
             ..Default::default()
         },
-        IpAddr::V6(ipv6) => NetworkAddress {
+        V6(ipv6) => NetworkAddress {
             address_type: Some(Family::Inet6.into()),
             packed_bytes: Some(ipv6.octets().to_vec()),
             ..Default::default()

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -3,6 +3,11 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
+//! A handler and associated types for the interfaces action.
+//!
+//! The interfaces action lists all network interfaces available for the client,
+//! collecting their names, MAC and IP addresses.
+
 use std::net::IpAddr;
 
 use ipnetwork::IpNetwork;
@@ -14,10 +19,13 @@ use rrg_proto::{Interface, NetworkAddress, network_address::Family};
 
 use crate::session::{self, Session};
 
+/// A response type for the interfaces action.
 pub struct Response {
+    /// Information about an interface.
     interface: NetworkInterface,
 }
 
+/// Handles requests for the interfaces action.
 pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     for interface in datalink::interfaces() {
         session.reply(Response {
@@ -28,10 +36,18 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     Ok(())
 }
 
+/// Converts a [`MacAddr`][mac_addr] to a vector of bytes,
+/// which is what protobuf expects as a MAC.
+///
+/// [mac_addr]: ../../../pnet/util/struct.MacAddr.html
 fn mac_to_vec(mac: MacAddr) -> Vec<u8> {
     vec![mac.0, mac.1, mac.2, mac.3, mac.4, mac.5]
 }
 
+/// Converts a single [`IpNetwork`][ip_network] to a protobuf struct
+/// corresponding to an IP address.
+///
+/// [ip_network]: ../../../ipnetwork/enum.IpNetwork.html
 fn ip_to_proto(ip_network: IpNetwork) -> NetworkAddress {
     match ip_network.ip() {
         IpAddr::V4(ipv4) => NetworkAddress {
@@ -47,6 +63,10 @@ fn ip_to_proto(ip_network: IpNetwork) -> NetworkAddress {
     }
 }
 
+/// Maps a vector of [`IpNetwork`][ip_network]s to a vector
+/// of protobuf structs corresponding to an IP address.
+///
+/// [ip_network]: ../../../ipnetwork/enum.IpNetwork.html
 fn ips_to_protos(ips: Vec<IpNetwork>) -> Vec<NetworkAddress> {
     ips.into_iter().map(ip_to_proto).collect()
 }

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -51,12 +51,12 @@ fn mac_to_vec(mac: MacAddr) -> Vec<u8> {
 fn ip_to_proto(ip_network: IpNetwork) -> NetworkAddress {
     match ip_network.ip() {
         IpAddr::V4(ipv4) => NetworkAddress {
-            address_type: Some(Family::Inet as i32),
+            address_type: Some(Family::Inet.into()),
             packed_bytes: Some(ipv4.octets().to_vec()),
             ..Default::default()
         },
         IpAddr::V6(ipv6) => NetworkAddress {
-            address_type: Some(Family::Inet6 as i32),
+            address_type: Some(Family::Inet6.into()),
             packed_bytes: Some(ipv6.octets().to_vec()),
             ..Default::default()
         },

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -8,6 +8,8 @@
 //! The interfaces action lists all network interfaces available on the client,
 //! collecting their names, MAC and IP addresses.
 
+use log::error;
+
 use ipnetwork::IpNetwork;
 use pnet::{
     datalink::{self, NetworkInterface},
@@ -81,7 +83,16 @@ impl super::Response for Response {
 
     fn into_proto(self) -> Interface {
         Interface {
-            mac_address: Some(mac_to_vec(self.interface.mac_address())),
+            mac_address: match self.interface.mac {
+                Some(mac) => Some(mac_to_vec(mac)),
+                None => {
+                    error!(
+                        "unable to get MAC address for {} interface",
+                        self.interface.name,
+                    );
+                    None
+                }
+            },
             ifname: Some(self.interface.name),
             addresses: ips_to_protos(self.interface.ips),
             ..Default::default()

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -82,17 +82,19 @@ impl super::Response for Response {
     type Proto = Interface;
 
     fn into_proto(self) -> Interface {
-        Interface {
-            mac_address: match self.interface.mac {
-                Some(mac) => Some(mac_to_vec(mac)),
-                None => {
-                    error!(
-                        "unable to get MAC address for {} interface",
-                        self.interface.name,
-                    );
-                    None
-                },
+        let mac = match self.interface.mac {
+            Some(mac) => Some(mac_to_vec(mac)),
+            None => {
+                error!(
+                    "unable to get MAC address for {} interface",
+                    self.interface.name,
+                );
+                None
             },
+        };
+
+        Interface {
+            mac_address: mac,
             ifname: Some(self.interface.name),
             addresses: ips_to_protos(self.interface.ips),
             ..Default::default()

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -1,0 +1,68 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+use std::net::IpAddr;
+
+use ipnetwork::IpNetwork;
+use pnet::{
+    datalink::{self, NetworkInterface},
+    util::MacAddr,
+};
+use rrg_proto::{Interface, NetworkAddress, network_address::Family};
+
+use crate::session::{self, Session};
+
+pub struct Response {
+    interface: NetworkInterface,
+}
+
+pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
+    for interface in datalink::interfaces() {
+        session.reply(Response {
+            interface: interface,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn mac_to_vec(mac: MacAddr) -> Vec<u8> {
+    vec![mac.0, mac.1, mac.2, mac.3, mac.4, mac.5]
+}
+
+fn ip_to_proto(ip_network: IpNetwork) -> NetworkAddress {
+    match ip_network.ip() {
+        IpAddr::V4(ipv4) => NetworkAddress {
+            address_type: Some(Family::Inet as i32),
+            packed_bytes: Some(ipv4.octets().to_vec()),
+            ..Default::default()
+        },
+        IpAddr::V6(ipv6) => NetworkAddress {
+            address_type: Some(Family::Inet6 as i32),
+            packed_bytes: Some(ipv6.octets().to_vec()),
+            ..Default::default()
+        },
+    }
+}
+
+fn ips_to_protos(ips: Vec<IpNetwork>) -> Vec<NetworkAddress> {
+    ips.into_iter().map(ip_to_proto).collect()
+}
+
+impl super::Response for Response {
+
+    const RDF_NAME: Option<&'static str> = Some("Interface");
+
+    type Proto = Interface;
+
+    fn into_proto(self) -> Interface {
+        Interface {
+            mac_address: Some(mac_to_vec(self.interface.mac_address())),
+            ifname: Some(self.interface.name),
+            addresses: ips_to_protos(self.interface.ips),
+            ..Default::default()
+        }
+    }
+}

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -18,7 +18,7 @@ use rrg_proto::{Interface, NetworkAddress};
 use crate::session::{self, Session};
 
 /// A response type for the interfaces action.
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug)]
 pub struct Response {
     /// Information about an interface.
     interface: NetworkInterface,
@@ -105,21 +105,5 @@ mod tests {
             is_loopback_present |= interface.is_loopback();
         }
         assert!(is_loopback_present);
-    }
-
-    #[test]
-    fn test_response_uniqueness() {
-        use std::collections::hash_set::HashSet;
-
-        let mut session = session::test::Fake::new();
-        assert!(handle(&mut session, ()).is_ok());
-
-        let mut responses =
-            HashSet::<&Response>::with_capacity(session.reply_count());
-        for i in 0..session.reply_count() {
-            let response = &session.reply::<Response>(i);
-            assert!(!responses.contains(response));
-            responses.insert(response);
-        }
     }
 }

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -91,7 +91,7 @@ impl super::Response for Response {
                         self.interface.name,
                     );
                     None
-                }
+                },
             },
             ifname: Some(self.interface.name),
             addresses: ips_to_protos(self.interface.ips),

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -10,9 +10,9 @@
 
 use log::error;
 
-use ipnetwork::IpNetwork;
 use pnet::{
     datalink::{self, NetworkInterface},
+    ipnetwork::IpNetwork,
     util::MacAddr,
 };
 use rrg_proto::{Interface, NetworkAddress};

--- a/src/action/interfaces.rs
+++ b/src/action/interfaces.rs
@@ -5,7 +5,7 @@
 
 //! A handler and associated types for the interfaces action.
 //!
-//! The interfaces action lists all network interfaces available for the client,
+//! The interfaces action lists all network interfaces available on the client,
 //! collecting their names, MAC and IP addresses.
 
 use ipnetwork::IpNetwork;

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
+pub mod interfaces;
 pub mod metadata;
 pub mod startup;
 
@@ -51,6 +52,7 @@ where
     match action {
         "SendStartupInfo" => task.execute(self::startup::handle),
         "GetClientInfo" => task.execute(self::metadata::handle),
+        "EnumerateInterfaces" => task.execute(self::interfaces::handle),
         action => return Err(session::Error::Dispatch(String::from(action))),
     }
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -18,7 +18,9 @@
 #[cfg(target_os = "linux")]
 pub mod filesystems;
 
+#[cfg(target_family = "unix")]
 pub mod interfaces;
+
 pub mod metadata;
 pub mod startup;
 pub mod network;
@@ -99,6 +101,8 @@ where
         "SendStartupInfo" => task.execute(self::startup::handle),
         "GetClientInfo" => task.execute(self::metadata::handle),
         "ListNetworkConnections" => task.execute(self::network::handle),
+
+        #[cfg(target_family = "unix")]
         "EnumerateInterfaces" => task.execute(self::interfaces::handle),
 
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
This pull request implements the `EnumerateInterfaces` action, closes #23.

I could not find anything about [these](https://github.com/google/grr/blob/f0c26b1e83e77a8f53f7b7aef706b418061682ae/grr/proto/grr_response_proto/jobs.proto#L969-L986) DHCP `Interface` protobuf parts in both [existing implementation](https://github.com/google/grr/blob/f0c26b1e83e77a8f53f7b7aef706b418061682ae/grr/client/grr_response_client/client_actions/linux/linux.py#L115) and the Rust lib I used ([`pnet`](https://docs.rs/pnet/0.25.0/pnet/index.html)). So I just left them blank.