### PR TITLE
Add the `EnumerateFilesystems` action

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ rust:
   - nightly
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install libfuse-dev
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install libfuse-dev; fi
 
 script:
   - cargo build --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ rust:
   - stable
   - nightly
 
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install libfuse-dev
+
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,15 @@ fleetspeak = { version = "0.1.2" }
 humantime = { version = "2.0.0" }
 log = { version = "0.4.8" }
 netstat2 = { version = "0.8.1" }
-proc-mounts = { version = "0.2.4" }
 prost = { version = "0.6.1" }
 prost-types = { version = "0.6.1" }
 rrg-proto = { path = "proto/" }
 simplelog = { version = "0.7.6" }
 structopt = { version = "0.3.12" }
 sysinfo = { version = "0.14.1" }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+proc-mounts = { version = "0.2.4" }
 
 [dev-dependencies]
 tempfile = { version = "3.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ rrg-proto = { path = "proto/" }
 simplelog = { version = "0.7.6" }
 structopt = { version = "0.3.12" }
 sys-info = { version = "0.5.1" }
+tempfile = { version = "3.1.0" }
+users = { version = "0.10.0" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 fuse = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 fleetspeak = { version = "0.1.1" }
-fuse = { version = "0.3.1 " }
 humantime = { version = "2.0.0" }
 log = { version = "0.4.8" }
 proc-mounts = { version = "0.2.4" }
@@ -17,3 +16,6 @@ rrg-proto = { path = "proto/" }
 simplelog = { version = "0.7.6" }
 structopt = { version = "0.3.12" }
 sys-info = { version = "0.5.1" }
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+fuse = { version = "0.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 
 [dependencies]
 fleetspeak = { version = "0.1.1" }
+fuse = { version = "0.3.1 " }
 humantime = { version = "2.0.0" }
 log = { version = "0.4.8" }
 proc-mounts = { version = "0.2.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ rrg-proto = { path = "proto/" }
 simplelog = { version = "0.7.6" }
 structopt = { version = "0.3.12" }
 sys-info = { version = "0.5.1" }
+
+[dev-dependencies]
 tempfile = { version = "3.1.0" }
-users = { version = "0.10.0" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 fuse = { version = "0.3.1" }
+users = { version = "0.10.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 fleetspeak = { version = "0.1.1" }
 humantime = { version = "2.0.0" }
 log = { version = "0.4.8" }
+proc-mounts = { version = "0.2.4" }
 prost = { version = "0.6.1" }
 prost-types = { version = "0.6.1" }
 rrg-proto = { path = "proto/" }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -8,6 +8,7 @@ use std::io::{Read, Write, Result};
 
 const PROTOS: &'static [&'static str] = &[
     "grr/grr/proto/grr_response_proto/semantic.proto",
+    "grr/grr/proto/grr_response_proto/sysinfo.proto",
     "grr/grr/proto/grr_response_proto/knowledge_base.proto",
     "grr/grr/proto/grr_response_proto/jobs.proto",
 ];

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -1,0 +1,77 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+use rrg_proto::{Filesystem, KeyValue, AttributedDict, DataBlob};
+use crate::session::{self, Session};
+
+pub struct Response {
+    mount_info: proc_mounts::MountInfo,
+}
+
+pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
+    for mount_info in proc_mounts::MountIter::new().unwrap() {
+        session.reply(Response {
+            mount_info: mount_info.unwrap(),
+        })?;
+    }
+    Ok(())
+}
+
+fn option_to_key_value(option: String) -> KeyValue {
+    match &option.split('=').collect::<Vec<&str>>()[..] {
+        &[key] => {
+            KeyValue {
+                k: Some(DataBlob {
+                    string: Some(String::from(key)),
+                    ..Default::default()
+                }),
+                v: None,
+            }
+        },
+        &[key, value] => {
+            KeyValue {
+                k: Some(DataBlob {
+                    string: Some(String::from(key)),
+                    ..Default::default()
+                }),
+                v: Some(DataBlob {
+                    string: Some(String::from(value)),
+                    ..Default::default()
+                }),
+            }
+        },
+        _ => {
+            // This is impossible.
+            panic!("Bad mount option")
+        },
+    }
+}
+
+fn options_to_dict(options: Vec<String>) -> AttributedDict {
+    AttributedDict {
+        dat: options.into_iter().map(option_to_key_value).collect(),
+    }
+}
+
+impl super::Response for Response {
+    const RDF_NAME: Option<&'static str> = Some("Filesystem");
+
+    type Proto = rrg_proto::Filesystem;
+
+    fn into_proto(self) -> Filesystem {
+        // TODO: remove lossy conversion of PathBuf to String
+        //   when mount_point field of Filesystem message
+        //   will have bytes type instead of string.
+        Filesystem {
+            device: Some(self.mount_info.source.into_os_string()
+                .into_string().unwrap_or_default()),
+            mount_point: Some(self.mount_info.dest.into_os_string()
+                .into_string().unwrap_or_default()),
+            r#type: Some(self.mount_info.fstype),
+            label: None,
+            options: Some(options_to_dict(self.mount_info.options)),
+        }
+    }
+}

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -42,7 +42,7 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
 }
 
 /// Converts filesystem mount option in `String` representation to
-/// `GRR`'s `KeyValue` protobuf struct representation.
+/// GRR's `KeyValue` protobuf struct representation.
 fn option_to_key_value(option: String) -> KeyValue {
     match &option.split('=').collect::<Vec<&str>>()[..] {
         &[key] => {
@@ -74,7 +74,7 @@ fn option_to_key_value(option: String) -> KeyValue {
 }
 
 /// Converts a `Vec` of filesystem mount options in `String` representation to
-/// `GRR`'s `AttributedDict` protobuf struct representation.
+/// GRR's `AttributedDict` protobuf struct representation.
 fn options_to_dict(options: Vec<String>) -> AttributedDict {
     AttributedDict {
         dat: options.into_iter().map(option_to_key_value).collect(),

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -239,12 +239,10 @@ mod tests {
 
         // `user_id` and `group_id` are set by libfuse.
         // http://man7.org/linux/man-pages/man8/mount.fuse.8.html
-        let current_uid_option = format!(
-            "user_id={}", get_current_uid().to_string());
+        let current_uid_option = format!("user_id={}", get_current_uid());
         assert!(options.iter().any(|opt| *opt == current_uid_option));
 
-        let current_gid_option = format!(
-            "group_id={}", get_current_gid().to_string());
+        let current_gid_option = format!("group_id={}", get_current_gid());
         assert!(options.iter().any(|opt| *opt == current_gid_option));
 
         drop(background_session);

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -19,9 +19,9 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug)]
 enum Error {
     /// Missed mtab-like file error.
-    MissedFile(std::io::Error),
+    MissingFile(std::io::Error),
     /// Parsing mtab-like file error.
-    MountInfoError(std::io::Error),
+    MountInfoParse(std::io::Error),
 }
 
 impl std::error::Error for Error {
@@ -30,8 +30,8 @@ impl std::error::Error for Error {
         use Error::*;
 
         match *self {
-            MissedFile(ref error) => Some(error),
-            MountInfoError(ref error) => Some(error),
+            MissingFile(ref error) => Some(error),
+            MountInfoParse(ref error) => Some(error),
         }
     }
 }
@@ -42,10 +42,10 @@ impl Display for Error {
         use Error::*;
 
         match *self {
-            MissedFile(ref error) => {
+            MissingFile(ref error) => {
                 write!(fmt, "missed file error: {}", error)
             },
-            MountInfoError(ref error) => {
+            MountInfoParse(ref error) => {
                 write!(fmt, "failed to obtain MountInfo: {}", error)
             },
         }
@@ -80,7 +80,7 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
             match MountIter::new_from_file("/etc/mtab") {
                 Ok(mount_iter) => mount_iter,
                 Err(error) => {
-                    return Err(session::Error::from(Error::MissedFile(error)))
+                    return Err(session::Error::from(Error::MissingFile(error)))
                 },
             }
         },
@@ -94,7 +94,7 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
                 })?;
             },
             Err(error) => {
-                return Err(session::Error::from(Error::MountInfoError(error)))
+                return Err(session::Error::from(Error::MountInfoParse(error)))
             },
         }
     }

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -216,7 +216,7 @@ mod tests {
 
         // Spawn a background thread to handle filesystem operations.
         // When `_background_session` is dropped, filesystem will be unmounted.
-        let _background_session = unsafe {
+        let background_session = unsafe {
             fuse::spawn_mount(FuseFilesystem, &mountpoint, &options).unwrap()
         };
 
@@ -246,5 +246,7 @@ mod tests {
         let current_gid_option = format!(
             "group_id={}", get_current_gid().to_string());
         assert!(options.iter().any(|opt| *opt == current_gid_option));
+
+        drop(background_session);
     }
 }

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -11,7 +11,16 @@ pub struct Response {
 }
 
 pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
-    for mount_info in proc_mounts::MountIter::new().unwrap() {
+    use proc_mounts::MountIter;
+    let mount_iter = match MountIter::new() {
+        Ok(mount_iter) => mount_iter,
+        Err(_) => {
+            // /etc/mtab must exist for sure.
+            MountIter::new_from_file("/etc/mtab").expect("/etc/mtab not found")
+        },
+    };
+
+    for mount_info in mount_iter {
         session.reply(Response {
             mount_info: mount_info.unwrap(),
         })?;

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -188,14 +188,11 @@ mod tests {
     }
 
     /// Unit-like struct, representing a filesystem for testing with `fuse`.
-    #[cfg(target_os = "linux")]
     struct FuseFilesystem;
 
-    #[cfg(target_os = "linux")]
     impl fuse::Filesystem for FuseFilesystem {}
 
     #[test]
-    #[cfg(target_os = "linux")]
     fn test_fuse_filesystem() {
         use users::{get_current_uid, get_current_gid};
 

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -87,8 +87,8 @@ impl super::Response for Response {
 
     fn into_proto(self) -> Filesystem {
         // TODO: remove lossy conversion of PathBuf to String
-        //   when mount_point field of Filesystem message
-        //   will have bytes type instead of string.
+        // when mount_point field of Filesystem message
+        // will have bytes type instead of string.
         Filesystem {
             device: Some(self.mount_info.source.into_os_string()
                 .into_string().unwrap_or_default()),

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -19,7 +19,7 @@ pub struct Response {
 }
 
 /// Handles requests for the filesystems action.
-/// Initially searches in `/proc/mounts`. If it's missed, fallbacks to
+/// Initially searches in `/proc/mounts`. If it's missed, falls back to
 /// `/etc/mtab`.
 pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     use proc_mounts::MountIter;
@@ -67,7 +67,7 @@ fn option_to_key_value(option: String) -> KeyValue {
         },
         _ => {
             // This is impossible.
-            panic!("Bad mount option")
+            panic!("Bad mount option");
         },
     }
 }

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -174,7 +174,7 @@ mod tests {
     use users::{get_current_uid, get_current_gid};
 
     #[test]
-    fn test_is_any_filesystem_exist() {
+    fn test_if_any_filesystem_exist() {
         let mut session = session::test::Fake::new();
         assert!(handle(&mut session, ()).is_ok());
         assert_ne!(session.reply_count(), 0);

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -46,7 +46,7 @@ impl Display for Error {
                 write!(fmt, "missed file error: {}", error)
             },
             MountInfoParse(ref error) => {
-                write!(fmt, "failed to obtain MountInfo: {}", error)
+                write!(fmt, "failed to obtain mount information: {}", error)
             },
         }
     }

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -209,6 +209,7 @@ mod tests {
             "-o", "nosuid",
             "-o", "nodev",
             "-o", "relatime",
+            "-o", "subtype=custom-type",
             "-o", &fs_name_option,
         ];
         let options = options.iter().map(|opt| opt.as_ref())
@@ -229,7 +230,7 @@ mod tests {
         let mount_info = &fuse_mounted_fs[0].mount_info;
         assert_eq!(mount_info.source, fs_name);
         assert_eq!(mount_info.dest, tmp_dir.path());
-        assert_eq!(mount_info.fstype, "fuse");
+        assert_eq!(mount_info.fstype, "fuse.custom-type");
 
         let options = &mount_info.options;
         assert!(options.iter().any(|opt| opt == "ro"));

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -96,6 +96,7 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
 fn option_to_key_value(option: String) -> KeyValue {
     match &option.split('=').collect::<Vec<&str>>()[..] {
         &[key] => {
+            // TODO: Simplify work with `DataBlob`.
             KeyValue {
                 k: Some(DataBlob {
                     string: Some(String::from(key)),

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -87,13 +87,13 @@ impl super::Response for Response {
 
     fn into_proto(self) -> Filesystem {
         // TODO: remove lossy conversion of PathBuf to String
-        // when mount_point field of Filesystem message
+        // when mount_point and device fields of Filesystem message
         // will have bytes type instead of string.
         Filesystem {
-            device: Some(self.mount_info.source.into_os_string()
-                .into_string().unwrap_or_default()),
-            mount_point: Some(self.mount_info.dest.into_os_string()
-                .into_string().unwrap_or_default()),
+            device: Some(self.mount_info.source.to_string_lossy()
+                .into_owned()),
+            mount_point: Some(self.mount_info.dest.to_string_lossy()
+                .into_owned()),
             r#type: Some(self.mount_info.fstype),
             label: None,
             options: Some(options_to_dict(self.mount_info.options)),

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -18,7 +18,7 @@ use std::fmt::{Display, Formatter};
 /// Enum of possible errors, which can occur during collecting filesystems data.
 #[derive(Debug)]
 enum Error {
-    /// Missed mtab-like file error.
+    /// Missing mtab-like file error.
     MissingFile(std::io::Error),
     /// Parsing mtab-like file error.
     MountInfoParse(std::io::Error),
@@ -67,7 +67,7 @@ pub struct Response {
 
 /// Handles requests for the filesystems action.
 ///
-/// Initially searches in `/proc/mounts`. If it's missed, falls back to
+/// Initially searches in `/proc/mounts`. If it's missing, falls back to
 /// `/etc/mtab`.
 pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     use proc_mounts::MountIter;

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -161,7 +161,6 @@ mod tests {
 
     use super::*;
     use std::path::PathBuf;
-    use users::{get_current_uid, get_current_gid};
 
     #[test]
     fn test_if_any_filesystem_exist() {
@@ -188,12 +187,17 @@ mod tests {
     }
 
     /// Unit-like struct, representing a filesystem for testing with `fuse`.
+    #[cfg(target_os = "linux")]
     struct FuseFilesystem;
 
+    #[cfg(target_os = "linux")]
     impl fuse::Filesystem for FuseFilesystem {}
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_fuse_filesystem() {
+        use users::{get_current_uid, get_current_gid};
+
         let fs_name = PathBuf::from("fuse-test-fs");
 
         let tmp_dir = tempfile::tempdir().unwrap();

--- a/src/action/filesystems.rs
+++ b/src/action/filesystems.rs
@@ -163,7 +163,7 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn test_if_any_filesystem_exist() {
+    fn test_if_any_filesystem_exists() {
         let mut session = session::test::Fake::new();
         assert!(handle(&mut session, ()).is_ok());
         assert_ne!(session.reply_count(), 0);

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -15,7 +15,9 @@
 //! instance of the corresponding request type and send some (zero or more)
 //! instances of the corresponding response type.
 
+#[cfg(target_os = "linux")]
 pub mod filesystems;
+
 pub mod metadata;
 pub mod startup;
 pub mod network;
@@ -95,8 +97,11 @@ where
     match action {
         "SendStartupInfo" => task.execute(self::startup::handle),
         "GetClientInfo" => task.execute(self::metadata::handle),
-        "EnumerateFilesystems" => task.execute(self::filesystems::handle),
         "ListNetworkConnections" => task.execute(self::network::handle),
+
+        #[cfg(target_os = "linux")]
+        "EnumerateFilesystems" => task.execute(self::filesystems::handle),
+
         action => return Err(session::Error::Dispatch(String::from(action))),
     }
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
+pub mod filesystems;
 pub mod metadata;
 pub mod startup;
 
@@ -52,6 +53,7 @@ where
     match action {
         "SendStartupInfo" => task.execute(self::startup::handle),
         "GetClientInfo" => task.execute(self::metadata::handle),
+        "EnumerateFilesystems" => task.execute(self::filesystems::handle),
         action => return Err(session::Error::Dispatch(String::from(action))),
     }
 }


### PR DESCRIPTION
This pull request implements the `EnumerateFilesystems` action, closes #21.

The list of filesystems I got from `/proc/mounts`. And if it's missed, implementation falls back to `/etc/mtab`. For parsing these mount-tab-like files, I used [proc_mounts](https://docs.rs/proc-mounts/0.2.4/proc_mounts/index.html) crate. 