### PR TITLE
Add `GetPlatformInfo` action

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ rrg-proto = { path = "proto/" }
 simplelog = { version = "0.7.6" }
 structopt = { version = "0.3.12" }
 sys-info = { version = "0.5.1" }
+libc = { version = "0.2" }

--- a/src/action/metadata.rs
+++ b/src/action/metadata.rs
@@ -36,3 +36,42 @@ impl super::Response for Response {
         self.metadata.into()
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_name() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+
+        let metadata = &session.reply::<Response>(0).metadata;
+        assert_eq!(metadata.name, "rrg");
+    }
+
+    #[test]
+    fn test_description() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+
+        let metadata = &session.reply::<Response>(0).metadata;
+        assert!(!metadata.description.is_empty());
+    }
+
+    #[test]
+    fn test_version() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+
+        let metadata = &session.reply::<Response>(0).metadata;
+        assert!(metadata.version.as_numeric() > 0);
+    }
+}

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod metadata;
 pub mod startup;
+pub mod platform_info;
 
 use crate::session::{self, Session, Task};
 
@@ -51,6 +52,7 @@ where
     match action {
         "SendStartupInfo" => task.execute(self::startup::handle),
         "GetClientInfo" => task.execute(self::metadata::handle),
+        "GetPlatformInfo" => task.execute(self::platform_info::handle),
         action => return Err(session::Error::Dispatch(String::from(action))),
     }
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -3,20 +3,61 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
+//! Handlers and types for agent's actions.
+//!
+//! The basic functionality that a GRR agent exposes is called an _action_.
+//! Actions are invoked by the server (when running a _flow_), should gather
+//! requested information and report back to the server.
+//!
+//! In RRG each action consists of three components: a request type, a response
+//! type and an action handler. Request and response types wrap lower-level
+//! Protocol Buffer messages sent by and to the GRR server. Handlers accept one
+//! instance of the corresponding request type and send some (zero or more)
+//! instances of the corresponding response type.
+
 pub mod metadata;
 pub mod startup;
 pub mod platform_info;
 
 use crate::session::{self, Session, Task};
 
-pub trait Request {
+/// Abstraction for action-specific requests.
+///
+/// Protocol Buffer messages received from the GRR server are not necessarily
+/// easy to work with and are hardly idiomatic to Rust. For this reason, actions
+/// should define more structured data types to represent their input and should
+/// be able to parse raw messages into them.
+pub trait Request: Sized {
+
+    /// A type of the corresponding raw proto message.
     type Proto: prost::Message + Default;
-    fn from_proto(proto: Self::Proto) -> Self;
+
+    /// A method for converting raw proto messages into structured requests.
+    fn from_proto(proto: Self::Proto) -> Result<Self, session::ParseError>;
 }
 
-pub trait Response {
+/// Abstraction for action-specific responses.
+///
+/// Like with the [`Request`] type, Protocol Buffer messages sent to the GRR
+/// server are very idiomatic to Rust. For this reason, actions should define
+/// more structured data types to represent responses and provide a way to
+/// convert them into the wire format.
+///
+/// Note that because of the design flaws in the protocol, actions also need to
+/// specify a name of the wrapper RDF class from the Python implementation.
+/// Hopefully, one day this issue would be fixed and class names will not leak
+/// into the specification.
+///
+/// [`Request`]: trait.Request.html
+pub trait Response: Sized {
+
+    /// A name of the corresponding RDF class.
     const RDF_NAME: Option<&'static str>;
+
+    /// A type of the corresponding raw proto message.
     type Proto: prost::Message + Default;
+
+    /// A method for converting structured responses into raw proto messages.
     fn into_proto(self) -> Self::Proto;
 }
 
@@ -24,7 +65,8 @@ impl Request for () {
 
     type Proto = ();
 
-    fn from_proto(_: ()) {
+    fn from_proto(unit: ()) -> Result<(), session::ParseError> {
+        Ok(unit)
     }
 }
 

--- a/src/action/platform_info.rs
+++ b/src/action/platform_info.rs
@@ -1,0 +1,106 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+extern crate sys_info;
+extern crate libc;
+// extern crate sysinfo;
+
+use sys_info::{linux_os_release, os_type, hostname};
+use libc::{uname, utsname, c_char};
+use std::ffi::CStr;
+use std::option::Option;
+use crate::session::{self, Session};
+
+use rrg_proto::Uname;
+
+#[derive(Default)]
+pub struct PlatformInfo {
+    system: Option<String>,
+    release_name: Option<String>,
+    version_id: Option<String>,
+    machine: Option<String>,
+    kernel_release: Option<String>,
+    fqdn: Option<String>,
+    architecture: Option<String>,
+    node: Option<String>
+}
+
+pub struct Response {
+    platform_information: PlatformInfo,
+}
+
+#[inline(always)]
+fn convert_raw_string(c_string: &[c_char]) -> String {
+    unsafe { 
+        String::from(CStr::from_ptr(c_string.as_ptr()).to_string_lossy().into_owned())
+    } 
+}
+
+pub fn handle<S: Session>(session:&mut S, _: ()) -> session::Result<()> {
+    let os_type = os_type().expect("Can't get os type");
+    match os_type.as_str() {
+        "Linux" => {
+            let linux_release_info = linux_os_release()
+                                        .expect("Can't get info about linux system");
+            let mut system_info: utsname;
+
+            unsafe {
+                system_info = std::mem::zeroed();
+                uname(&mut system_info);
+            }
+
+            session.reply(Response {
+                platform_information: PlatformInfo {
+                    system: Some(os_type.to_string()),
+                    release_name: linux_release_info.name,
+                    version_id: linux_release_info.version_id,
+                    machine: Some(convert_raw_string(&system_info.machine)),
+                    kernel_release: Some(convert_raw_string(&system_info.release)),
+                    fqdn: hostname().ok(),
+                    architecture: Some(convert_raw_string(&system_info.machine)),
+                    node: Some(convert_raw_string(&system_info.nodename))
+                },
+            })?;
+        },
+
+        _ => {
+            session.reply(Response {
+                platform_information: PlatformInfo {
+                    system: Some(os_type.to_string()),
+                    fqdn: hostname().ok(),
+                    ..Default::default() // TODO: Add other systems
+                }
+            })?;
+        }
+    }
+
+    Ok(())
+}
+
+impl super::Response for Response {
+    const RDF_NAME: Option<&'static str> = Some("Uname");
+
+    type Proto = Uname;
+
+    fn into_proto(self) -> Uname {
+        Uname {
+            system: self.platform_information.system.clone(),
+            release: self.platform_information.release_name.clone(),
+            version: self.platform_information.version_id,
+            machine: self.platform_information.machine,
+            kernel: self.platform_information.kernel_release,
+            fqdn: self.platform_information.fqdn,
+            architecture: self.platform_information.architecture.clone(),
+            node: self.platform_information.node,
+            pep425tag: Some(
+                format!("{}_{}_{}", 
+                    self.platform_information.system.unwrap_or(String::from("")), 
+                    self.platform_information.release_name.unwrap_or(String::from("")), 
+                    self.platform_information.architecture.unwrap_or(String::from(""))
+            )),
+            ..Default::default()
+        }
+    }
+}

--- a/src/action/platform_info.rs
+++ b/src/action/platform_info.rs
@@ -4,8 +4,9 @@
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
 extern crate sys_info;
+
+/// Using for `uname` syscall.
 extern crate libc;
-// extern crate sysinfo;
 
 use sys_info::{linux_os_release, os_type, hostname};
 use libc::{uname, utsname, c_char};
@@ -15,6 +16,7 @@ use crate::session::{self, Session};
 
 use rrg_proto::Uname;
 
+/// Structure that contains information about client platform.
 #[derive(Default)]
 pub struct PlatformInfo {
     system: Option<String>,
@@ -27,10 +29,13 @@ pub struct PlatformInfo {
     node: Option<String>
 }
 
+/// A Response type for `GetPlatformInfo` action
 pub struct Response {
+    /// Client platform information
     platform_information: PlatformInfo,
 }
 
+/// Funcion that converts raw C-strings into `String` type
 #[inline(always)]
 fn convert_raw_string(c_string: &[c_char]) -> String {
     unsafe { 
@@ -38,6 +43,8 @@ fn convert_raw_string(c_string: &[c_char]) -> String {
     } 
 }
 
+/// Handles requests for `GetPlatformInfo` action.
+/// Currently works fine only for Linux OS.
 pub fn handle<S: Session>(session:&mut S, _: ()) -> session::Result<()> {
     let os_type = os_type().expect("Can't get os type");
     match os_type.as_str() {
@@ -82,9 +89,10 @@ pub fn handle<S: Session>(session:&mut S, _: ()) -> session::Result<()> {
 impl super::Response for Response {
     const RDF_NAME: Option<&'static str> = Some("Uname");
 
-    type Proto = Uname;
+    type Proto = rrg_proto::Uname;
 
-    fn into_proto(self) -> Uname {
+    /// Convert PlatformInformation struct to protobuf message Uname
+    fn into_proto(self) -> rrg_proto::Uname {
         Uname {
             system: self.platform_information.system.clone(),
             release: self.platform_information.release_name.clone(),
@@ -101,6 +109,124 @@ impl super::Response for Response {
                     self.platform_information.architecture.unwrap_or(String::from(""))
             )),
             ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_system() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        assert_eq!(platform_info.system.as_ref().unwrap(), sys_info::os_type().as_ref().unwrap());
+    }
+
+    #[test]
+    fn test_linux_release() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        if sys_info::os_type().unwrap() == "Linux" {
+            assert_eq!(platform_info.release_name.as_ref().unwrap(), sys_info::linux_os_release().unwrap().name.as_ref().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_linux_version() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        if sys_info::os_type().unwrap() == "Linux" {
+            assert_eq!(platform_info.version_id.as_ref().unwrap(), sys_info::linux_os_release().unwrap().version_id.as_ref().unwrap());
+        }
+    }
+
+    #[test]
+    fn test_linux_machine() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        if sys_info::os_type().unwrap() == "Linux" {
+            let mut system_info: utsname;
+
+            unsafe {
+                system_info = std::mem::zeroed();
+                uname(&mut system_info);
+            }
+            assert_eq!(platform_info.machine.as_ref().unwrap(), &convert_raw_string(&system_info.machine));
+        }
+    }
+
+    #[test]
+    fn test_linux_kernel_release() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        if sys_info::os_type().unwrap() == "Linux" {
+            let mut system_info: utsname;
+
+            unsafe {
+                system_info = std::mem::zeroed();
+                uname(&mut system_info);
+            }
+            assert_eq!(platform_info.kernel_release.as_ref().unwrap(), &convert_raw_string(&system_info.release));
+        }
+    }
+
+    #[test]
+    fn test_linux_architecture() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        if sys_info::os_type().unwrap() == "Linux" {
+            let mut system_info: utsname;
+
+            unsafe {
+                system_info = std::mem::zeroed();
+                uname(&mut system_info);
+            }
+            assert_eq!(platform_info.architecture.as_ref().unwrap(), &convert_raw_string(&system_info.machine));
+        }
+    }
+
+    #[test]
+    fn test_linux_node() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+        let platform_info = &session.reply::<Response>(0).platform_information;
+
+        if sys_info::os_type().unwrap() == "Linux" {
+            let mut system_info: utsname;
+
+            unsafe {
+                system_info = std::mem::zeroed();
+                uname(&mut system_info);
+            }
+            assert_eq!(platform_info.node.as_ref().unwrap(), &convert_raw_string(&system_info.nodename));
         }
     }
 }

--- a/src/action/startup.rs
+++ b/src/action/startup.rs
@@ -18,6 +18,7 @@ use log::error;
 use crate::metadata::{Metadata};
 use crate::session::{self, Session};
 
+/// An error type for failures that can occur when collecting startup data.
 #[derive(Debug)]
 struct Error {
     boot_time_error: sys_info::Error,
@@ -99,5 +100,37 @@ impl super::Response for Response {
             client_info: Some(self.metadata.into()),
             boot_time: Some(boot_time_micros),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_boot_time() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 0);
+        assert_eq!(session.response_count(session::Sink::STARTUP), 1);
+
+        let response = session.response::<Response>(session::Sink::STARTUP, 0);
+        assert!(response.boot_time > std::time::UNIX_EPOCH);
+        assert!(response.boot_time < std::time::SystemTime::now());
+    }
+
+    #[test]
+    fn test_metadata() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 0);
+        assert_eq!(session.response_count(session::Sink::STARTUP), 1);
+
+        let response = session.response::<Response>(session::Sink::STARTUP, 0);
+        assert!(response.metadata.version.as_numeric() > 0);
+        assert_eq!(response.metadata.name, "rrg");
     }
 }

--- a/src/session/demand.rs
+++ b/src/session/demand.rs
@@ -60,7 +60,7 @@ impl Payload {
             None => Default::default(),
         };
 
-        Ok(R::from_proto(proto))
+        R::from_proto(proto)
     }
 }
 
@@ -69,15 +69,15 @@ impl TryFrom<rrg_proto::GrrMessage> for Demand {
     type Error = session::ParseError;
 
     fn try_from(message: rrg_proto::GrrMessage) -> Result<Demand, Self::Error> {
-        use session::ParseError::*;
+        let missing = session::MissingFieldError::new;
 
         let header = Header {
-            session_id: message.session_id.ok_or(MissingField("session id"))?,
-            request_id: message.request_id.ok_or(MissingField("request id"))?,
+            session_id: message.session_id.ok_or(missing("session id"))?,
+            request_id: message.request_id.ok_or(missing("request id"))?,
         };
 
         Ok(Demand {
-            action: message.name.ok_or(MissingField("action name"))?,
+            action: message.name.ok_or(missing("action name"))?,
             header: header,
             payload: Payload {
                 data: message.args,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -26,7 +26,7 @@ use log::{error, info};
 use crate::action;
 use crate::message;
 pub use self::demand::{Demand, Header, Payload};
-pub use self::error::{Error, ParseError};
+pub use self::error::{Error, ParseError, MissingFieldError};
 use self::response::{Response, Status};
 pub use self::sink::{Sink};
 
@@ -118,11 +118,16 @@ where
 pub trait Session {
     /// Sends a reply to the flow that call the action.
     fn reply<R>(&mut self, response: R) -> Result<()>
-    where R: action::Response;
+    where R: action::Response + 'static;
 
     /// Sends a message to a particular sink.
     fn send<R>(&mut self, sink: Sink, response: R) -> Result<()>
-    where R: action::Response;
+    where R: action::Response + 'static;
+
+    /// Sends a heartbeat signal to the Fleetspeak process.
+    fn heartbeat(&mut self) {
+        // TODO: Create a real implementation.
+    }
 }
 
 /// A session type for unrequested action executions.
@@ -242,4 +247,277 @@ where
     message::send(message);
 
     Ok(())
+}
+
+#[cfg(test)]
+pub mod test {
+    use std::any::Any;
+    use std::collections::HashMap;
+
+    use super::*;
+
+    /// A session type intended to be used in tests.
+    ///
+    /// Testing actions with normal session objects can be quite hard, since
+    /// they communicate with the outside world (through Fleetspeak). Since we
+    /// want to keep the tests minimal and not waste resources on unneeded I/O,
+    /// using real sessions is not an option.
+    ///
+    /// Instead, one can use a `Fake` session. It simply accumulates responses
+    /// that the action sends and lets the creator inspect them later.
+    pub struct Fake {
+        replies: Vec<Box<dyn Any>>,
+        responses: HashMap<Sink, Vec<Box<dyn Any>>>,
+    }
+
+    impl Fake {
+
+        /// Constructs a new fake session.
+        pub fn new() -> Fake {
+            Fake {
+                replies: Vec::new(),
+                responses: std::collections::HashMap::new(),
+            }
+        }
+
+        /// Yields the number of replies that this session sent so far.
+        pub fn reply_count(&self) -> usize {
+            self.replies.len()
+        }
+
+        /// Retrieves a reply corresponding to the given id.
+        ///
+        /// The identifier corresponding to the first response is 0, the second
+        /// one is 1 and so on.
+        ///
+        /// This method will panic if a reply with the specified `id` does not
+        /// exist or if it exists but has a wrong type.
+        pub fn reply<R>(&self, id: usize) -> &R
+        where
+            R: action::Response + 'static,
+        {
+            let reply = match self.replies.get(id) {
+                Some(reply) => reply,
+                None => panic!("no reply #{}", id),
+            };
+
+            reply.downcast_ref().expect("unexpected reply type")
+        }
+
+        /// Yields the number of responses sent so far to the specified sink.
+        pub fn response_count(&self, sink: Sink) -> usize {
+            match self.responses.get(&sink) {
+                Some(responses) => responses.len(),
+                None => 0,
+            }
+        }
+
+        /// Retrieves a response with the given id sent to a particular sink.
+        ///
+        /// The identifier corresponding to the first response to the particular
+        /// sink is 0, to the second one (to the same sink) is 1 and so on.
+        ///
+        /// This method will panic if a reply with the specified `id` to the
+        /// given `sink` does not exist or if it exists but has wrong type.
+        pub fn response<R>(&self, sink: Sink, id: usize) -> &R
+        where
+            R: action::Response + 'static,
+        {
+            let responses = match self.responses.get(&sink) {
+                Some(responses) => responses,
+                None => panic!("no responses for sink '{:?}'", sink),
+            };
+
+            let response = match responses.get(id) {
+                Some(response) => response,
+                None => panic!("no response #{} for sink '{:?}'", id, sink),
+            };
+
+            match response.downcast_ref() {
+                Some(response) => response,
+                None => panic!("unexpected response type in sink '{:?}'", sink),
+            }
+        }
+    }
+
+    impl Session for Fake {
+
+        fn reply<R>(&mut self, response: R) -> Result<()>
+        where
+            R: action::Response + 'static,
+        {
+            self.replies.push(Box::new(response));
+
+            Ok(())
+        }
+
+        fn send<R>(&mut self, sink: Sink, response: R) -> Result<()>
+        where
+            R: action::Response + 'static,
+        {
+            let responses = self.responses.entry(sink).or_insert_with(Vec::new);
+            responses.push(Box::new(response));
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_fake_reply_count() {
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.reply(()).unwrap();
+            session.reply(()).unwrap();
+            session.reply(()).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        assert_eq!(session.reply_count(), 3);
+    }
+
+    #[test]
+    fn test_fake_response_count() {
+
+        // TODO: Extend this test with more sinks (once we have some more sinks
+        // defined).
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.send(Sink::STARTUP, ()).unwrap();
+            session.send(Sink::STARTUP, ()).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        assert_eq!(session.response_count(Sink::STARTUP), 2);
+    }
+
+    #[test]
+    fn test_fake_reply_correct_response() {
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.reply(StringResponse::from("foo")).unwrap();
+            session.reply(StringResponse::from("bar")).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        assert_eq!(session.reply::<StringResponse>(0).0, "foo");
+        assert_eq!(session.reply::<StringResponse>(1).0, "bar");
+    }
+
+    #[test]
+    #[should_panic(expected = "no reply #0")]
+    fn test_fake_reply_incorrect_response_id() {
+
+        fn handle<S: Session>(_: &mut S, _: ()) {
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        session.reply::<()>(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected reply type")]
+    fn test_fake_reply_incorrect_response_type() {
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.reply(StringResponse::from("quux")).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        session.reply::<()>(0);
+    }
+
+    #[test]
+    fn test_fake_response_correct_response() {
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.send(Sink::STARTUP, StringResponse::from("foo")).unwrap();
+            session.send(Sink::STARTUP, StringResponse::from("bar")).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        let response_foo = session.response::<StringResponse>(Sink::STARTUP, 0);
+        let response_bar = session.response::<StringResponse>(Sink::STARTUP, 1);
+        assert_eq!(response_foo.0, "foo");
+        assert_eq!(response_bar.0, "bar");
+    }
+
+    #[test]
+    #[should_panic(expected = "no responses")]
+    fn test_fake_response_empty_sink() {
+
+        fn handle<S: Session>(_: &mut S, _: ()) {
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        session.response::<()>(Sink::STARTUP, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "no response #42")]
+    fn test_fake_response_incorrect_response_id() {
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.send(Sink::STARTUP, ()).unwrap();
+            session.send(Sink::STARTUP, ()).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        session.response::<()>(Sink::STARTUP, 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "unexpected response type")]
+    fn test_fake_response_incorrect_response_type() {
+
+        fn handle<S: Session>(session: &mut S, _: ()) {
+            session.send(Sink::STARTUP, StringResponse::from("quux")).unwrap();
+        }
+
+        let mut session = test::Fake::new();
+        handle(&mut session, ());
+
+        session.response::<()>(Sink::STARTUP, 0);
+    }
+
+    struct StringResponse(String);
+
+    impl<S: Into<String>> From<S> for StringResponse {
+
+        fn from(string: S) -> StringResponse {
+            StringResponse(string.into())
+        }
+    }
+
+    impl action::Response for StringResponse {
+
+        const RDF_NAME: Option<&'static str> = Some("RDFString");
+
+        type Proto = String;
+
+        fn into_proto(self) -> String {
+            self.0
+        }
+    }
 }

--- a/src/session/sink.rs
+++ b/src/session/sink.rs
@@ -17,7 +17,7 @@ use crate::action;
 use crate::session;
 
 /// Handle to a specific sink.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 pub struct Sink {
     /// An underlying identifier of the sink.
     id: &'static str,


### PR DESCRIPTION
This pull request implements the `GetPlatformInfo` action, closes #6.

I left `libc_ver` and `install_date` fields blank because function `Uname.FromCurrentSystem` ([link](https://github.com/google/grr/blob/f0c26b1e83e77a8f53f7b7aef706b418061682ae/grr/core/grr_response_core/lib/rdfvalues/client.py#L536)) doesn't fill them. I also add [libc crate](https://docs.rs/libc/0.2.70/libc/) which provides `uname` system call.

All fields, except `libc_ver` and `install_date`, are currently filled for Linux.