### PR TITLE
Add the `GetMemorySize` action

### DIFF
--- a/src/action/memory_size.rs
+++ b/src/action/memory_size.rs
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+//! A handler and associated types for the `GetMemorySize` action.
+//!
+//! The `GetMemorySize` action returns the RAM size in bytes.
+
+use sysinfo::SystemExt;
+use crate::session::{self, Session};
+
+pub struct Response {
+    memory_size: u64
+}
+
+pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
+    let mut system = sysinfo::System::new();
+    system.refresh_all();
+    session.reply(Response {
+        memory_size: system.get_total_memory() * 1024
+    })?;
+    Ok(())
+}
+
+/// A response type for the `GetMemorySize` action.
+impl super::Response for Response {
+
+    const RDF_NAME: Option<&'static str> = Some("ByteSize");
+
+    type Proto = String;
+
+    fn into_proto(self) -> Self::Proto {
+        self.memory_size.to_string()
+    }
+}

--- a/src/action/memory_size.rs
+++ b/src/action/memory_size.rs
@@ -34,3 +34,19 @@ impl super::Response for Response {
         self.memory_size.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test() {
+        let mut session = session::test::Fake::new();
+        assert!(handle(&mut session, ()).is_ok());
+
+        assert_eq!(session.reply_count(), 1);
+
+        let memory_size = session.reply::<Response>(0).memory_size;
+        assert!(memory_size > 0);
+    }
+}

--- a/src/action/memsize.rs
+++ b/src/action/memsize.rs
@@ -16,7 +16,7 @@ pub struct Response {
 
 pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     let mut system = sysinfo::System::new();
-    system.refresh_all();
+    system.refresh_system();
     session.reply(Response {
         memory_size: system.get_total_memory() * 1024
     })?;

--- a/src/action/memsize.rs
+++ b/src/action/memsize.rs
@@ -29,7 +29,7 @@ impl super::Response for Response {
     const RDF_NAME: Option<&'static str> = Some("ByteSize");
 
     type Proto = String;
-    //TODO: Fix serialization issues.
+    // TODO: Fix serialization issues.
 
     fn into_proto(self) -> Self::Proto {
         self.memory_size.to_string()

--- a/src/action/memsize.rs
+++ b/src/action/memsize.rs
@@ -3,9 +3,9 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
-//! A handler and associated types for the `GetMemorySize` action.
+//! A handler and associated types for the memory size action.
 //!
-//! The `GetMemorySize` action returns the RAM size in bytes.
+//! The `memory size` action returns the RAM size in bytes.
 
 use sysinfo::SystemExt;
 use crate::session::{self, Session};
@@ -23,7 +23,7 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     Ok(())
 }
 
-/// A response type for the `GetMemorySize` action.
+/// A response type for the memory size action.
 impl super::Response for Response {
 
     const RDF_NAME: Option<&'static str> = Some("ByteSize");

--- a/src/action/memsize.rs
+++ b/src/action/memsize.rs
@@ -5,7 +5,7 @@
 
 //! A handler and associated types for the memory size action.
 //!
-//! The `memory size` action returns the RAM size in bytes.
+//! The memory size action returns the RAM size in bytes.
 
 use sysinfo::SystemExt;
 use crate::session::{self, Session};
@@ -29,6 +29,7 @@ impl super::Response for Response {
     const RDF_NAME: Option<&'static str> = Some("ByteSize");
 
     type Proto = String;
+    //TODO: Fix serialization issues.
 
     fn into_proto(self) -> Self::Proto {
         self.memory_size.to_string()

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -24,6 +24,7 @@ pub mod interfaces;
 pub mod metadata;
 pub mod startup;
 pub mod network;
+pub mod memory_size;
 
 use crate::session::{self, Session, Task};
 
@@ -108,6 +109,8 @@ where
         #[cfg(target_os = "linux")]
         "EnumerateFilesystems" => task.execute(self::filesystems::handle),
 
+
+        "GetMemorySize" => task.execute(self::memory_size::handle),
         action => return Err(session::Error::Dispatch(String::from(action))),
     }
 }

--- a/src/action/mod.rs
+++ b/src/action/mod.rs
@@ -24,7 +24,7 @@ pub mod interfaces;
 pub mod metadata;
 pub mod startup;
 pub mod network;
-pub mod memory_size;
+pub mod memsize;
 
 use crate::session::{self, Session, Task};
 
@@ -110,7 +110,7 @@ where
         "EnumerateFilesystems" => task.execute(self::filesystems::handle),
 
 
-        "GetMemorySize" => task.execute(self::memory_size::handle),
+        "GetMemorySize" => task.execute(self::memsize::handle),
         action => return Err(session::Error::Dispatch(String::from(action))),
     }
 }


### PR DESCRIPTION
This pull request implements the `GetMemorySize` action, closes https://github.com/google/rrg/issues/7.