### PR TITLE
Replace the `rust-crypto` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ regex = { version = "1.5.5" }
 lazy_static = { version = "1.4.0" }
 
 chrono = { version = "0.4.11", optional = true }
+digest = { version = "0.10.5", optional = true }
 flate2 = { version = "1.0.14", optional = true }
 md-5 = { version = "0.10.5", optional = true }
 netstat2 = { version = "0.8.1", optional = true }
@@ -68,7 +69,7 @@ default = [
 action-insttime = ["dep:chrono", "dep:proc-mounts", "dep:winreg"]
 action-interfaces = ["dep:pnet"]
 action-filesystems = ["dep:proc-mounts"]
-action-finder = ["dep:md-5", "dep:sha1", "dep:sha2"]
+action-finder = ["dep:digest", "dep:md-5", "dep:sha1", "dep:sha2"]
 action-listdir = []
 action-memsize = ["dep:sysinfo"]
 action-metadata = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,10 @@ lazy_static = { version = "1.4.0" }
 
 chrono = { version = "0.4.11", optional = true }
 flate2 = { version = "1.0.14", optional = true }
+md-5 = { version = "0.10.5", optional = true }
 netstat2 = { version = "0.8.1", optional = true }
-# TODO: Remove `rust-crypto` from project dependencies altogether. It is no
-# longer maintained and can be replaced by smaller and more specialized crates.
-rust-crypto = { version = "0.2.36", optional = true }
-sha2 = { version = "0.8.1", optional = true }
+sha1 = { version = "0.10.5", optional = true }
+sha2 = { version = "0.10.6", optional = true }
 sysinfo = { version = "0.14.1", optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
@@ -69,7 +68,7 @@ default = [
 action-insttime = ["dep:chrono", "dep:proc-mounts", "dep:winreg"]
 action-interfaces = ["dep:pnet"]
 action-filesystems = ["dep:proc-mounts"]
-action-finder = ["dep:rust-crypto", "dep:sha2"]
+action-finder = ["dep:md-5", "dep:sha1", "dep:sha2"]
 action-listdir = []
 action-memsize = ["dep:sysinfo"]
 action-metadata = []

--- a/src/action/finder/hash.rs
+++ b/src/action/finder/hash.rs
@@ -1,10 +1,11 @@
 use crate::action::finder::request::HashActionOptions;
 use crate::fs::Entry;
+use digest::Digest as _;
 use log::warn;
 use md5::Md5;
 use rrg_macro::ack;
 use sha1::Sha1;
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use std::cmp::min;
 use std::fs::File;
 use std::io::Read;


### PR DESCRIPTION
Replaces the [rust-crypto](https://crates.io/crates/rust-crypto) crate with distributed implementations of various hash algorithms that use the traits from the [digest](https://crates.io/crates/digest) crate. See [RustCrypto/hashes](https://github.com/RustCrypto/hashes) for implementations which use this trait.

* SHA-1 hash: [sha1](https://crates.io/crates/sha1)
* SHA-256 hash: [sha2](https://crates.io/crates/sha2)
* MD5 hash: [md-5](https://crates.io/crates/md-5)