### PR TITLE
Add the GetHostname action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
           command: test
           args: >
             --workspace
-            --features 'test-chattr test-setfattr test-fuse'
+            --features 'test-chattr test-setfattr test-hostname test-fuse'

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ addons:
 
 script:
   - cargo build --verbose
-  - cargo test --verbose --package rrg-macro --package rrg-proto --package rrg --features 'test-chattr test-setfattr'
+  - cargo test --verbose --package rrg-macro --package rrg-proto --package rrg --features 'test-chattr test-setfattr test-hostname'
   - cargo run -- --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,7 @@ proc-mounts = { version = "0.2.4", optional = true }
 fuse = { version = "0.3.1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_System_SystemInformation"], optional = true }
-windows-sys = { version = "0.42.0", features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_System_Registry"] }
+windows-sys = { version = "0.42.0", features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_WindowsProgramming"] }
 
 [dev-dependencies]
 rand = { version = "0.8.5" }
@@ -69,7 +68,7 @@ action-insttime = ["dep:chrono", "dep:proc-mounts"]
 action-interfaces = []
 action-filesystems = ["dep:proc-mounts"]
 action-finder = ["dep:digest", "dep:md-5", "dep:sha1", "dep:sha2"]
-action-hostname = ["dep:windows"]
+action-hostname = []
 action-listdir = []
 action-memsize = ["dep:sysinfo"]
 action-metadata = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ action-timeline = ["dep:flate2", "dep:sha2"]
 
 test-chattr = []
 test-setfattr = []
+test-hostname = []
 test-fuse = ["dep:fuse"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ proc-mounts = { version = "0.2.4", optional = true }
 fuse = { version = "0.3.1", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.43.0", features = ["Win32_Foundation", "Win32_System_SystemInformation"], optional = true }
 windows-sys = { version = "0.42.0", features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock", "Win32_System_Registry"] }
 
 [dev-dependencies]
@@ -55,6 +56,7 @@ default = [
     "action-interfaces",
     "action-filesystems",
     "action-finder",
+    "action-hostname",
     "action-listdir",
     "action-memsize",
     "action-metadata",
@@ -67,6 +69,7 @@ action-insttime = ["dep:chrono", "dep:proc-mounts"]
 action-interfaces = []
 action-filesystems = ["dep:proc-mounts"]
 action-finder = ["dep:digest", "dep:md-5", "dep:sha1", "dep:sha2"]
+action-hostname = ["dep:windows"]
 action-listdir = []
 action-memsize = ["dep:sysinfo"]
 action-metadata = []

--- a/src/action.rs
+++ b/src/action.rs
@@ -49,6 +49,9 @@ pub mod memsize;
 #[cfg(feature = "action-finder")]
 pub mod finder;
 
+#[cfg(feature = "action-hostname")]
+pub mod hostname;
+
 pub use error::{ParseArgsError, ParseArgsErrorKind, DispatchError};
 
 /// Dispatches the given `request` to an appropriate action handler.
@@ -113,6 +116,11 @@ where
         #[cfg(feature = "action-memsize")]
         "GetMemorySize" => {
             handle(session, request, self::memsize::handle)
+        }
+
+        #[cfg(feature = "action-hostname")]
+        "GetHostname" => {
+            handle(session, request, self::hostname::handle)
         }
 
         action_name => {

--- a/src/action/hostname.rs
+++ b/src/action/hostname.rs
@@ -118,6 +118,7 @@ pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
     session.reply(Response {hostname: get_hostname()})
 }
 
+#[cfg(feature = "test-hostname")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/action/hostname.rs
+++ b/src/action/hostname.rs
@@ -6,22 +6,7 @@
 //! A handler and associated types for the hostname action.
 
 use crate::session::{self, Session};
-#[cfg(target_family = "unix")]
-use libc::c_char;
-#[cfg(target_family = "unix")]
-use std::ffi::CStr;
 use std::ffi::OsString;
-#[cfg(target_family = "unix")]
-use std::io::Error;
-#[cfg(target_family = "unix")]
-use std::os::unix::prelude::OsStringExt as _;
-#[cfg(target_os = "windows")]
-use std::os::windows::ffi::OsStringExt as _;
-#[cfg(target_os = "windows")]
-use windows::{
-    core::{Error, PWSTR},
-    Win32::System::SystemInformation::{ComputerNamePhysicalDnsHostname, GetComputerNameExW},
-};
 
 /// A response type for the hostname action.
 struct Response {
@@ -42,95 +27,138 @@ impl super::Item for Response {
     }
 }
 
+/// An error type for failures that can occur during the hostname action.
+#[derive(Debug)]
+enum Error {
+    /// Hostname error.
+    Hostname(std::io::Error),
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            Hostname(ref error) => Some(error),
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use Error::*;
+
+        match *self {
+            Hostname(ref error) => {
+                write!(fmt, "unable to get hostname: {}", error)
+            }
+        }
+    }
+}
+
+impl From<Error> for session::Error {
+    fn from(error: Error) -> session::Error {
+        session::Error::action(error)
+    }
+}
+
 /// Obtains system hostname (Unix version).
 ///
 /// This function returns `std::io::Error` in case of errors.
 #[cfg(target_family = "unix")]
-fn get_hostname() -> Result<OsString, Error> {
-    let hostname_max_size = unsafe { libc::sysconf(libc::_SC_HOST_NAME_MAX) as libc::size_t };
+fn get_hostname() -> Result<OsString, std::io::Error> {
+    use libc::c_char;
+    use std::ffi::CStr;
+    use std::io::Error;
+    use std::os::unix::prelude::OsStringExt as _;
 
-    let mut hostname = vec![0_u8 as c_char; hostname_max_size + 1];
+    let hostname_max_len = unsafe { libc::sysconf(libc::_SC_HOST_NAME_MAX) as libc::size_t };
 
-    let result = unsafe { libc::gethostname(hostname.as_mut_ptr(), hostname_max_size) };
+    let mut hostname_data = vec![0_u8 as c_char; hostname_max_len + 1];
+    let hostname_data_ptr = hostname_data.as_mut_ptr();
 
-    if result != 0 {
-        Err(Error::last_os_error())
+    let code = unsafe { libc::gethostname(hostname_data_ptr, hostname_max_len) };
+    if code != 0 {
+        Err(Error::from_raw_os_error(code))
     } else {
-        let hostname =
-            unsafe { OsString::from_vec(CStr::from_ptr(hostname.as_ptr()).to_bytes().to_vec()) };
+        let hostname = unsafe { CStr::from_ptr(hostname_data_ptr).to_bytes().to_vec() };
 
-        Ok(hostname)
+        Ok(OsString::from_vec(hostname))
     }
 }
 
 /// Obtains system hostname (Windows version).
 ///
-/// This function returns `windows::core::Error` in case of errors.
+/// This function returns `std::io::Error` in case of errors.
 #[cfg(target_os = "windows")]
-fn get_hostname() -> Result<OsString, Error> {
-    let mut computer_name_size = 0;
-    unsafe {
-        GetComputerNameExW(
-            ComputerNamePhysicalDnsHostname,
-            PWSTR::null(),
-            &mut computer_name_size,
-        );
+fn get_hostname() -> Result<OsString, std::io::Error> {
+    use std::io::Error;
+    use std::mem::MaybeUninit;
+    use std::os::windows::ffi::OsStringExt as _;
+    use std::slice;
+    use windows_sys::Win32::System::{
+        SystemInformation::{ComputerNamePhysicalDnsHostname, GetComputerNameExW},
+        WindowsProgramming::MAX_COMPUTERNAME_LENGTH,
     };
 
-    let mut computer_name = vec![0_u16; computer_name_size as usize];
-    unsafe {
+    let mut computer_name_data = MaybeUninit::<[u16; MAX_COMPUTERNAME_LENGTH as usize]>::uninit();
+    let mut computer_name_len = MAX_COMPUTERNAME_LENGTH;
+    let result = unsafe {
         GetComputerNameExW(
             ComputerNamePhysicalDnsHostname,
-            PWSTR::from_raw(computer_name.as_mut_ptr()),
-            &mut computer_name_size,
+            computer_name_data.as_mut_ptr().cast(),
+            &mut computer_name_len,
         )
-    }
-    .ok()?;
+    };
+    if result != 1 {
+        Err(Error::last_os_error())
+    } else {
+        let computer_name = unsafe {
+            slice::from_raw_parts::<u16>(
+                computer_name_data.assume_init().as_ptr(),
+                computer_name_len as usize,
+            )
+        };
 
-    unsafe {
-        computer_name.set_len(computer_name_size as usize);
+        Ok(OsString::from_wide(computer_name))
     }
-
-    Ok(OsString::from_wide(&computer_name))
 }
 
 /// Handles requests for the hostname action.
 pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
-    session.reply(Response {
-        hostname: get_hostname()?,
-    })
+    let hostname = get_hostname().map_err(Error::Hostname)?;
+
+    session.reply(Response { hostname })
 }
 
 #[cfg(feature = "test-hostname")]
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{BufRead, ErrorKind};
+    use std::io::BufRead;
     use std::process::{Command, Stdio};
 
     #[test]
     fn test_hostname() {
         let mut session = session::FakeSession::new();
-
-        if let Err(err) = handle(&mut session, ()) {
-            panic!("{:?}", err);
-        };
+        handle(&mut session, ()).unwrap();
 
         assert_eq!(session.reply_count(), 1);
         let response: &Response = session.reply(0);
-        let hostname = response.hostname.as_ref().unwrap();
 
-        let output = match Command::new("hostname").stdout(Stdio::piped()).spawn() {
-            Ok(child) => child.wait_with_output().ok().unwrap(),
-            Err(err) if err.kind() == ErrorKind::NotFound => return,
-            Err(err) => panic!("{}", err),
-        };
+        let output = Command::new("hostname")
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap()
+            .wait_with_output()
+            .ok()
+            .unwrap();
 
         assert!(output.status.success());
 
         let first_line = output.stdout.lines().next().unwrap();
         let expect = first_line.unwrap();
 
-        assert_eq!(hostname.to_string_lossy().to_string(), expect);
+        assert_eq!(response.hostname.to_string_lossy().to_string(), expect);
     }
 }

--- a/src/action/hostname.rs
+++ b/src/action/hostname.rs
@@ -1,0 +1,151 @@
+// Copyright 2020 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+//! A handler and associated types for the hostname action.
+
+#[cfg(target_family = "unix")]
+use libc::c_char;
+use log::error;
+#[cfg(target_family = "unix")]
+use std::ffi::CStr;
+#[cfg(target_os = "windows")]
+use std::ffi::OsString;
+#[cfg(target_os = "windows")]
+use std::os::windows::ffi::OsStringExt;
+#[cfg(target_os = "windows")]
+use windows::{
+    Win32::System::SystemInformation::{
+        ComputerNamePhysicalDnsHostname, GetComputerNameExW,
+    },
+    core::PWSTR
+};
+use crate::session::{self, Session};
+
+/// A response type for the hostname action.
+struct Response {
+    /// The host name reported by the kernel, or `None` if the attemps to
+    /// obtain the host name failed.
+    hostname: Option<String>,
+}
+
+impl super::Item for Response {
+    const RDF_NAME: &'static str = "DataBlob";
+
+    type Proto = protobuf::well_known_types::StringValue;
+
+    fn into_proto(self) -> Self::Proto {
+        let hostname = match self.hostname {
+            Some(hostname) => hostname,
+            None => {
+                error!("cannot get hostname, all methods failed");
+                String::new()
+            },
+        };
+
+        let mut proto = protobuf::well_known_types::StringValue::new();
+        proto.set_value(hostname);
+
+        proto
+    }
+}
+
+/// Obtains system hostname (Unix version).
+///
+/// This function returns `None` in case of errors.
+#[cfg(target_family = "unix")]
+fn get_hostname() -> Option<String> {
+	let size =
+        unsafe { libc::sysconf(libc::_SC_HOST_NAME_MAX) as libc::size_t };
+
+    let mut buf = vec![0 as c_char; size];
+
+    let p = buf.as_mut_ptr();
+    let result = unsafe {
+        libc::gethostname(p, size)
+    };
+
+    if result != 0 {
+        None
+    } else {
+        let hostname = 
+            unsafe { String::from_utf8_lossy(CStr::from_ptr(p).to_bytes()).into() };
+
+        Some(hostname)
+    }
+}
+
+/// Obtains system hostname (Windows version).
+///
+/// This function returns `None` in case of errors.
+#[cfg(target_os = "windows")]
+fn get_hostname() -> Option<String> {
+    let mut size = 0;
+    unsafe {
+        GetComputerNameExW(
+            ComputerNamePhysicalDnsHostname,
+            PWSTR::null(),
+            &mut size,
+        );
+    };
+
+    let mut buf = vec![0_u16; size as usize];
+    let result = unsafe {
+        GetComputerNameExW(
+            ComputerNamePhysicalDnsHostname,
+            PWSTR::from_raw(buf.as_mut_ptr()),
+            &mut size,
+        )
+    };
+
+    if result.as_bool() {
+        unsafe { buf.set_len(size as usize); }
+
+        Some(OsString::from_wide(&buf).to_string_lossy().to_string())
+    } else {
+        None
+    }
+}
+
+/// Handles requests for the hostname action.
+pub fn handle<S: Session>(session: &mut S, _: ()) -> session::Result<()> {
+    session.reply(Response {hostname: get_hostname()})?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{BufRead, ErrorKind};
+    use std::process::{Command, Stdio};
+
+    #[test]
+    fn test_hostname() {
+        let output = match Command::new("hostname")
+            .stdout(Stdio::piped())
+            .spawn() {
+            Ok(child) => child.wait_with_output().ok().unwrap(),
+            Err(err) => {
+                if let ErrorKind::NotFound = err.kind() {
+                    return
+                }
+
+                panic!("{}", err);
+            }, 
+        };
+
+        assert!(output.status.success());
+
+        let first_line = output.stdout.lines().next().unwrap();
+        let expect = first_line.unwrap();
+
+        let mut session = session::FakeSession::new();
+        assert!(handle(&mut session, ()).is_ok());
+        assert_eq!(session.reply_count(), 1);
+        let response: &Response = session.reply(0);
+        let hostname = response.hostname.clone().unwrap();
+
+        assert_eq!(hostname, expect);
+    }
+}

--- a/src/action/hostname.rs
+++ b/src/action/hostname.rs
@@ -71,7 +71,6 @@ fn get_hostname() -> Result<OsString, Error> {
     if result != 0 {
         Err(Error::last_os_error())
     } else {
-        buf.push(0);
         let hostname = unsafe {
             OsString::from_vec(CStr::from_ptr(buf.as_ptr()).to_bytes().to_vec())
         };

--- a/src/action/hostname.rs
+++ b/src/action/hostname.rs
@@ -59,7 +59,7 @@ impl super::Item for Response {
 /// This function returns `std::io::Error` in case of errors.
 #[cfg(target_family = "unix")]
 fn get_hostname() -> Result<OsString, Error> {
-	let size =
+    let size =
         unsafe { libc::sysconf(libc::_SC_HOST_NAME_MAX) as libc::size_t };
 
     let mut buf = vec![0_u8 as c_char; size + 1];

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -19,12 +19,6 @@ pub struct Error {
 pub enum ErrorKind {
     /// The action execution failed.
     ExecutionFailure,
-    /// I/O error.
-    #[cfg(target_family = "unix")]
-    IoError(std::io::ErrorKind),
-    /// Windows error.
-    #[cfg(target_os = "windows")]
-    WindowsError,
 }
 
 impl Error {
@@ -51,10 +45,6 @@ impl ErrorKind {
 
         match *self {
             ExecutionFailure => "action execution failed",
-            #[cfg(target_family = "unix")]
-            IoError(_) => "I/O error",
-            #[cfg(target_os = "windows")]
-            WindowsError => "Windows error",
         }
     }
 }
@@ -70,28 +60,6 @@ impl std::error::Error for Error {
 
     fn cause(&self) -> Option<&dyn std::error::Error> {
         Some(self.error.as_ref())
-    }
-}
-
-#[cfg(target_family = "unix")]
-impl From<std::io::Error> for Error {
-
-    fn from(error: std::io::Error) -> Self {
-        Error {
-            kind: ErrorKind::IoError(error.kind()),
-            error: Box::new(error),
-        }
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl From<windows::core::Error> for Error {
-
-    fn from(error: windows::core::Error) -> Self {
-        Error {
-            kind: ErrorKind::WindowsError,
-            error: Box::new(error),
-        }
     }
 }
 


### PR DESCRIPTION
Adds the [`GetHostname`](https://github.com/google/grr/blob/f0c26b1e83e77a8f53f7b7aef706b418061682ae/grr/client/grr_response_client/client_actions/admin.py#L50-L57) action. The implementation follows Python's [`socket.gethostname`](https://docs.python.org/3/library/socket.html#socket.gethostname). This PR adds Microsoft's [windows](https://crates.io/crates/windows) crate that provides convenient bindings for Windows.

* unix: [syscall gethostname](https://linux.die.net/man/2/gethostname) ([`libc::gethostname`](https://docs.rs/libc/0.2.137/libc/fn.gethostname.html))
* windows: [GetComputerNameExW function (sysinfoapi.h)](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getcomputernameexw) using the [windows](https://crates.io/crates/windows) crate.

Tests

The test is inspired by Go's [`os.Hostname`](https://pkg.go.dev/os#Hostname) test and uses the hostname program. The test will be skipped, if the hostname program does not exist. On Linux, the hostname program is not installed on all distributions by default (the program exists for example on Ubuntu).

* linux: https://linux.die.net/man/1/hostname
* bsd (darwin): https://www.freebsd.org/cgi/man.cgi?query=hostname
* windows: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/hostname

References

* Python socketmodule.c https://github.com/python/cpython/blob/8b24d60f1b7725d526ea5b5d3904b72e8b41ae0d/Modules/socketmodule.c#L5569
* sys_linux.go https://github.com/golang/go/blob/f229e7031a6efb2f23241b5da000c3b3203081d6/src/os/sys_linux.go#L12
* sys_windows.go https://github.com/golang/go/blob/f229e7031a6efb2f23241b5da000c3b3203081d6/src/os/sys_windows.go
* sys_bsd.go (darwin) https://github.com/golang/go/blob/f229e7031a6efb2f23241b5da000c3b3203081d6/src/os/sys_bsd.go

Resolves #4