### PR TITLE
Make `get_system_metadata` errors non-critical

### DIFF
--- a/crates/rrg/src/action/get_system_metadata.rs
+++ b/crates/rrg/src/action/get_system_metadata.rs
@@ -2,34 +2,71 @@
 //
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
+use log::error;
 
 /// A result of the the `get_system_metadata` action.
 struct Item {
     /// The kind of the operating system the agent is running on.
     kind: ospect::os::Kind,
     /// Version string of the operating system the agent is running on.
-    version: String,
+    version: Option<String>,
     /// CPU architecture of the operating system the agent is running on.
-    arch: String,
+    arch: Option<String>,
     /// Hostname of the operating system the agent is running on.
-    hostname: std::ffi::OsString,
+    hostname: Option<std::ffi::OsString>,
     /// FQDN of the operating system the agent is running on.
-    fqdn: std::ffi::OsString,
+    fqdn: Option<std::ffi::OsString>,
     /// Estimated time at which the operating system was installed.
-    installed: std::time::SystemTime,
+    installed: Option<std::time::SystemTime>,
 }
 
 impl Item {
 
     /// Returns metadata of the operating system the agent is running on.
     fn new() -> std::io::Result<Item> {
+        let version = match ospect::os::version() {
+            Ok(version) => Some(version),
+            Err(error) => {
+                error!("failed to collect system version: {error}");
+                None
+            }
+        };
+        let arch = match ospect::os::arch() {
+            Ok(arch) => Some(arch),
+            Err(error) => {
+                error!("failed to collect system architecture: {error}");
+                None
+            }
+        };
+        let hostname = match ospect::os::hostname() {
+            Ok(hostname) => Some(hostname),
+            Err(error) => {
+                error!("failed to collect system hostname: {error}");
+                None
+            }
+        };
+        let fqdn = match ospect::os::fqdn() {
+            Ok(fqdn) => Some(fqdn),
+            Err(error) => {
+                error!("failed to collect system FQDN: {error}");
+                None
+            }
+        };
+        let installed = match ospect::os::installed() {
+            Ok(installed) => Some(installed),
+            Err(error) => {
+                error!("failed to collect system installation time: {error}");
+                None
+            }
+        };
+
         Ok(Item {
             kind: ospect::os::kind(),
-            version: ospect::os::version()?,
-            arch: ospect::os::arch()?,
-            hostname: ospect::os::hostname()?,
-            fqdn: ospect::os::fqdn()?,
-            installed: ospect::os::installed()?,
+            version,
+            arch,
+            hostname,
+            fqdn,
+            installed,
         })
     }
 }
@@ -43,11 +80,21 @@ impl crate::response::Item for Item {
 
         let mut proto = rrg_proto::get_system_metadata::Result::new();
         proto.set_field_type(self.kind.into());
-        proto.set_version(self.version);
-        proto.set_arch(self.arch);
-        proto.set_hostname(self.hostname.to_string_lossy().into_owned());
-        proto.set_fqdn(self.fqdn.to_string_lossy().into_owned());
-        proto.set_install_time(into_timestamp(self.installed));
+        if let Some(version) = self.version {
+            proto.set_version(version);
+        }
+        if let Some(arch) = self.arch {
+            proto.set_arch(arch);
+        }
+        if let Some(hostname) = self.hostname {
+            proto.set_hostname(hostname.to_string_lossy().into_owned());
+        }
+        if let Some(fqdn) = self.fqdn {
+            proto.set_fqdn(fqdn.to_string_lossy().into_owned());
+        }
+        if let Some(installed) = self.installed {
+            proto.set_install_time(into_timestamp(installed));
+        }
 
         proto
     }


### PR DESCRIPTION
Due to #58, currently all invocations of the `get_system_metadata` action fail on new versions of macOS. Failure to collect any of the system metadata pieces should not be critical and the action should always succeed, even if information is incomplete.