### PR TITLE
Extend `get_file_metadata` with directory walking

### DIFF
--- a/proto/rrg/action/get_file_metadata.proto
+++ b/proto/rrg/action/get_file_metadata.proto
@@ -9,12 +9,21 @@ package rrg.action.get_file_metadata;
 import "rrg/fs.proto";
 
 message Args {
-  // Path to the file to get the metadata for.
+  // Root path to the file to get the metadata for.
+  //
+  // If `max_depth` is non-zero, metadata for subfolders and their contents up
+  // to that limit are returned as well.
   //
   // Note that if a path points to a symbolic link, the metadata associated
   // with the link itself will be returned, not the metadata of the file that
   // the link points to.
   rrg.fs.Path path = 1;
+
+  // Limit on the depth of recursion when visiting subfolders.
+  //
+  // The default value (0) means that there is no recursion and only metadata
+  // about the root path is returned.
+  uint32 max_depth = 2;
 }
 
 message Result {


### PR DESCRIPTION
By using the `max_depth` argument action callers can now query metadata for many items in the given folder. In a sense, it unifies the old [`GetFileStat`], [`StatFS`] and [`ListDirectory`] actions without making the interface much more complex. Moreover, combined with filter functionality this can be also used as a replacement for the file-finder action for simple cases.

[`GetFileStat`]: https://github.com/google/grr/blob/a6f1b31abfe82794b7d82fa8d54d8bd94bfed1bb/grr/client/grr_response_client/client_actions/standard.py#L187-L203
[`StatFS`]: https://github.com/google/grr/blob/a6f1b31abfe82794b7d82fa8d54d8bd94bfed1bb/grr/client/grr_response_client/client_actions/standard.py#L477-L492
[`ListDirectory`]: https://github.com/google/grr/blob/a6f1b31abfe82794b7d82fa8d54d8bd94bfed1bb/grr/client/grr_response_client/client_actions/standard.py#L160-L178