### PR TITLE
Add support for digest in `get_file_metadata`

### DIFF
--- a/crates/rrg/Cargo.toml
+++ b/crates/rrg/Cargo.toml
@@ -10,6 +10,7 @@ default = [
     "action-get_system_metadata",
     "action-get_file_metadata",
     "action-get_file_metadata-md5",
+    "action-get_file_metadata-sha256",
     "action-get_file_contents",
     "action-grep_file_contents",
     "action-get_filesystem_timeline",
@@ -25,6 +26,7 @@ default = [
 action-get_system_metadata = []
 action-get_file_metadata = []
 action-get_file_metadata-md5 = ["action-get_file_metadata", "dep:md-5"]
+action-get_file_metadata-sha256 = ["action-get_file_metadata", "dep:sha2"]
 action-get_file_contents = ["dep:sha2"]
 action-grep_file_contents = []
 action-get_filesystem_timeline = ["dep:flate2", "dep:sha2"]

--- a/crates/rrg/Cargo.toml
+++ b/crates/rrg/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 default = [
     "action-get_system_metadata",
     "action-get_file_metadata",
+    "action-get_file_metadata-md5",
     "action-get_file_contents",
     "action-grep_file_contents",
     "action-get_filesystem_timeline",
@@ -23,6 +24,7 @@ default = [
 
 action-get_system_metadata = []
 action-get_file_metadata = []
+action-get_file_metadata-md5 = ["action-get_file_metadata", "dep:md-5"]
 action-get_file_contents = ["dep:sha2"]
 action-grep_file_contents = []
 action-get_filesystem_timeline = ["dep:flate2", "dep:sha2"]

--- a/crates/rrg/Cargo.toml
+++ b/crates/rrg/Cargo.toml
@@ -10,6 +10,7 @@ default = [
     "action-get_system_metadata",
     "action-get_file_metadata",
     "action-get_file_metadata-md5",
+    "action-get_file_metadata-sha1",
     "action-get_file_metadata-sha256",
     "action-get_file_contents",
     "action-grep_file_contents",
@@ -26,6 +27,7 @@ default = [
 action-get_system_metadata = []
 action-get_file_metadata = []
 action-get_file_metadata-md5 = ["action-get_file_metadata", "dep:md-5"]
+action-get_file_metadata-sha1 = ["action-get_file_metadata", "dep:sha1"]
 action-get_file_metadata-sha256 = ["action-get_file_metadata", "dep:sha2"]
 action-get_file_contents = ["dep:sha2"]
 action-grep_file_contents = []

--- a/crates/rrg/src/action/get_file_metadata.rs
+++ b/crates/rrg/src/action/get_file_metadata.rs
@@ -80,6 +80,15 @@ where
     let path = path.map_err(crate::session::Error::action)?;
     let symlink = symlink.transpose().map_err(crate::session::Error::action)?;
 
+    // We log warnings here instead of the `digest` method to avoid repeated
+    // messages for (potential) child files.
+    if args.md5 && !cfg!(feature = "action-get_file_metadata-md5") {
+        log::warn!("MD5 digest requested but not supported");
+    }
+    if args.sha256 && !cfg!(feature = "action-get_file_metadata-sha256") {
+        log::warn!("SHA-256 digest requested but not supported");
+    }
+
     session.reply(Item {
         path: path.clone(),
         metadata,

--- a/proto/rrg/action/get_file_metadata.proto
+++ b/proto/rrg/action/get_file_metadata.proto
@@ -31,6 +31,13 @@ message Args {
   //
   // [1]: https://en.wikipedia.org/wiki/MD5
   bool md5 = 3;
+
+  // Whether to collect [SHA-256 digest][2] of the file contents.
+  //
+  // Supported only if the `action-get_file_metadata-sha256` feature is enabled.
+  //
+  // [1]: https://en.wikipedia.org/wiki/SHA-2
+  bool sha256 = 4;
 }
 
 message Result {
@@ -60,4 +67,12 @@ message Result {
   //
   // [1]: https://en.wikipedia.org/wiki/MD5
   bytes md5 = 5;
+
+  // [SHA-256 digest][1] of the file contents.
+  //
+  // Collected only if the `action-get_file_metadata-sha256` feature is enabled
+  // and `sha256` argument was provided.
+  //
+  // [1]: https://en.wikipedia.org/wiki/SHA-2
+  bytes sha256 = 6;
 }

--- a/proto/rrg/action/get_file_metadata.proto
+++ b/proto/rrg/action/get_file_metadata.proto
@@ -24,6 +24,13 @@ message Args {
   // The default value (0) means that there is no recursion and only metadata
   // about the root path is returned.
   uint32 max_depth = 2;
+
+  // Whether to collect [MD5 digest][1] of the file contents.
+  //
+  // Supported only if the `action-get_file_metadata-md5` feature is enabled.
+  //
+  // [1]: https://en.wikipedia.org/wiki/MD5
+  bool md5 = 3;
 }
 
 message Result {
@@ -45,4 +52,12 @@ message Result {
   // Note that this path might be relative. Moreover, it is not canonicalized
   // in any way and might not even exist (a dangling symlink).
   rrg.fs.Path symlink = 4;
+
+  // [MD5 digest][1] of the file contents.
+  //
+  // Collected only if the `action-get_file_metadata-md5` feature is enabled
+  // and `md5` argument was provided.
+  //
+  // [1]: https://en.wikipedia.org/wiki/MD5
+  bytes md5 = 5;
 }

--- a/proto/rrg/action/get_file_metadata.proto
+++ b/proto/rrg/action/get_file_metadata.proto
@@ -32,6 +32,13 @@ message Args {
   // [1]: https://en.wikipedia.org/wiki/MD5
   bool md5 = 3;
 
+  // Whether to collect [SHA-1 digest][1] of the file contents.
+  //
+  // Supported only if the `action-get_file_metadata-sha1` feature is enabled.
+  //
+  // [1]: https://en.wikipedia.org/wiki/SHA-1
+  bool sha1 = 5;
+
   // Whether to collect [SHA-256 digest][2] of the file contents.
   //
   // Supported only if the `action-get_file_metadata-sha256` feature is enabled.
@@ -67,6 +74,14 @@ message Result {
   //
   // [1]: https://en.wikipedia.org/wiki/MD5
   bytes md5 = 5;
+
+  // [SHA-1 digest][1] of the file contents.
+  //
+  // Collected only if the `action-get_file_metadata-sha1` feature is enabled
+  // and `sha1` argument was provided.
+  //
+  // [1]: https://en.wikipedia.org/wiki/SHA-1
+  bytes sha1 = 7;
 
   // [SHA-256 digest][1] of the file contents.
   //

--- a/proto/rrg/action/get_file_metadata.proto
+++ b/proto/rrg/action/get_file_metadata.proto
@@ -37,14 +37,14 @@ message Args {
   // Supported only if the `action-get_file_metadata-sha1` feature is enabled.
   //
   // [1]: https://en.wikipedia.org/wiki/SHA-1
-  bool sha1 = 5;
+  bool sha1 = 4;
 
   // Whether to collect [SHA-256 digest][2] of the file contents.
   //
   // Supported only if the `action-get_file_metadata-sha256` feature is enabled.
   //
   // [1]: https://en.wikipedia.org/wiki/SHA-2
-  bool sha256 = 4;
+  bool sha256 = 5;
 }
 
 message Result {
@@ -81,7 +81,7 @@ message Result {
   // and `sha1` argument was provided.
   //
   // [1]: https://en.wikipedia.org/wiki/SHA-1
-  bytes sha1 = 7;
+  bytes sha1 = 6;
 
   // [SHA-256 digest][1] of the file contents.
   //
@@ -89,5 +89,5 @@ message Result {
   // and `sha256` argument was provided.
   //
   // [1]: https://en.wikipedia.org/wiki/SHA-2
-  bytes sha256 = 6;
+  bytes sha256 = 7;
 }


### PR DESCRIPTION
At the moment we only support collection of MD5, SHA-1 and SHA-256 (the same three algorithms [supported][1] in the Python agent) but this PR establishes a framework for easy expansion in the future.

[1]: https://github.com/google/grr/blob/aa5df4c961546a5bb0d43462d5255609b964892d/grr/proto/grr_response_proto/jobs.proto#L1038-L1047