### PR TITLE
Rename the proto message for command spec

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -181,7 +181,7 @@ impl crate::request::Args for Args {
 
         let raw_command = proto.take_command();
         let mut command =
-            rrg_proto::execute_signed_command::SignedCommand::parse_from_bytes(&raw_command)
+            rrg_proto::execute_signed_command::Command::parse_from_bytes(&raw_command)
                 .map_err(|error| ParseArgsError::invalid_field("command", error))?;
 
         let path = std::path::PathBuf::try_from(command.take_path())
@@ -414,7 +414,7 @@ mod tests {
         let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
         let mut session = prepare_session(signing_key.verifying_key());
 
-        let mut command = rrg_proto::execute_signed_command::SignedCommand::new();
+        let mut command = rrg_proto::execute_signed_command::Command::new();
         command.set_path(PathBuf::from("ls").into());
 
         let raw_command = command.write_to_bytes().unwrap();

--- a/proto/rrg/action/execute_signed_command.proto
+++ b/proto/rrg/action/execute_signed_command.proto
@@ -10,7 +10,7 @@ package rrg.action.execute_signed_command;
 import "google/protobuf/duration.proto";
 import "rrg/fs.proto";
 
-message SignedCommand {
+message Command {
   // Path to the executable file to execute.
   rrg.fs.Path path = 1;
 
@@ -34,7 +34,7 @@ message SignedCommand {
 }
 
 message Args {
-  // Serialized `SignedCommand` message to execute.
+  // Serialized `Command` message to execute.
   bytes command = 1;
 
   // Standard input to pass to the executed command.


### PR DESCRIPTION
`SignedCommand` can be a bit confusing as it does not contain a signature—instead the name was implying that it is _supposed_ to be signed. However, when implementing things on GRR server-side, it became obvious that this brings too much confusion and it is better to just use `Command`.