### PR TITLE
Adjust command execution timeout mechanism

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -532,7 +532,7 @@ mod tests {
     #[cfg(target_family = "unix")]
     #[test]
     fn handle_kill_if_timeout() {
-        let timeout = std::time::Duration::from_secs(5);
+        let timeout = std::time::Duration::from_secs(0);
 
         let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
         let mut session = prepare_session(signing_key.verifying_key());
@@ -565,7 +565,7 @@ mod tests {
     #[cfg(target_family = "windows")]
     #[test]
     fn handle_kill_if_timeout() {
-        let timeout = std::time::Duration::from_secs(5);
+        let timeout = std::time::Duration::from_secs(0);
 
         let signing_key = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
         let mut session = prepare_session(signing_key.verifying_key());

--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -13,7 +13,7 @@ use protobuf::Message;
 
 // TODO(s-westphal): Check and update max size.
 const MAX_OUTPUT_SIZE: usize = 4048;
-const COMMAND_EXECUTION_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+const COMMAND_EXECUTION_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
 /// Arguments of the `execute_signed_command` action.
 pub struct Args {

--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -82,7 +82,7 @@ where
         None => return Err(crate::session::Error::action(MissingCommandVerificationKeyError)),
     };
 
-    let mut command_process = Command::new(args.path)
+    let mut command_process = Command::new(&args.path)
         .stdin(std::process::Stdio::piped())
         .args(args.args)
         .env_clear()
@@ -118,6 +118,7 @@ where
     // more input incoming.
     drop(command_stdin);
 
+    log::info!("starting '{}' (timeout: {:?})", args.path.display(), args.timeout);
     loop {
         let time_elapsed = command_start_time.elapsed();
         let time_left = args.timeout.saturating_sub(time_elapsed);
@@ -128,10 +129,6 @@ where
 
         match command_process.try_wait() {
             Ok(None) => {
-                log::debug!(
-                    "command not completed, waiting {:?}",
-                    COMMAND_EXECUTION_CHECK_INTERVAL
-                );
                 std::thread::sleep(std::cmp::min(COMMAND_EXECUTION_CHECK_INTERVAL, time_left));
             }
             _ => break,


### PR DESCRIPTION
With this pull request we wait only for as long as needed, in case the timeout is not a multiple of the check interval. This allows the test to no longer block.