### PR TITLE
Use hostname as primary FQDN source on macOS

### DIFF
--- a/crates/ospect/src/os.rs
+++ b/crates/ospect/src/os.rs
@@ -140,8 +140,6 @@ mod tests {
     }
 
     #[test]
-    // TODO(#58): `ospect::os::fqdn` is broken on macOS.
-    #[cfg_attr(target_os = "macos", ignore)]
     fn fqdn_not_empty() {
         assert!(!fqdn().unwrap().is_empty());
     }

--- a/crates/ospect/src/os/macos.rs
+++ b/crates/ospect/src/os/macos.rs
@@ -31,6 +31,17 @@ pub fn hostname() -> std::io::Result<std::ffi::OsString> {
 }
 
 /// Returns the FQDN of the currently running operating system.
+/// Returns the hostname if it already contains a dot.
 pub fn fqdn() -> std::io::Result<std::ffi::OsString> {
+    let hostname = crate::os::unix::hostname()?;
+
+    // If the hostname contains a dot, it's likely already a FQDN.
+    // It might not be resolvable though so calling
+    // crate::os::unix::fqdn() could fail.
+    use std::os::unix::ffi::OsStrExt;
+    if hostname.as_bytes().contains(&b'.') {
+        return Ok(hostname);
+    }
+
     crate::os::unix::fqdn()
 }


### PR DESCRIPTION
Fixes: #58 

See explanation in: https://github.com/google/rrg/issues/58#issuecomment-2759571908