### PR TITLE
Adjust command execution output size limits

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -211,11 +211,7 @@ where
             Ok(Err(error)) => {
                 return Err(crate::session::Error::action(CommandExecutionError(error)))
             }
-            Err(error) => {
-                // TODO(@panhania): While this should never happen, we should be
-                // able to handle it more gracefully.
-                panic!("writer thread panicked: {:?}", error);
-            }
+            Err(error) => std::panic::resume_unwind(error),
         }
     }
 
@@ -224,11 +220,7 @@ where
         Ok(Err(error)) => {
             return Err(crate::session::Error::action(CommandExecutionError(error)))
         }
-        Err(error) => {
-            // TODO(@panhania): While this should never happen, we should be
-            // able to handle it more gracefully.
-            panic!("reader thread panicked: {:?}", error)
-        }
+        Err(error) => std::panic::resume_unwind(error),
     };
 
     let stderr = match reader_stderr.join() {
@@ -236,11 +228,7 @@ where
         Ok(Err(error)) => {
             return Err(crate::session::Error::action(CommandExecutionError(error)))
         }
-        Err(error) => {
-            // TODO(@panhania): While this should never happen, we should be
-            // able to handle it more gracefully.
-            panic!("reader thread panicked: {:?}", error)
-        }
+        Err(error) => std::panic::resume_unwind(error),
     };
 
     session.reply(Item {

--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -162,6 +162,10 @@ where
     if let Some(writer) = writer {
         match writer.join() {
             Ok(Ok(())) => (),
+            Ok(Err(error)) if error.kind() == std::io::ErrorKind::BrokenPipe => {
+                // We ignore broken pipe errors when writing as this can happen
+                // if the action finished early or timed out.
+            }
             Ok(Err(error)) => {
                 return Err(crate::session::Error::action(CommandExecutionError(error)))
             }


### PR DESCRIPTION
Increasing the output size limit uncovered several issues, mainly caused by my #93 (we cannot write on the main thread!) and #88 (we cannot stop reading the input after the bit we are actually interested in!). Most of that should be explained by the comments in code.