### PR TITLE
Hide a `wtmp`-dependent test behind a feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,4 @@ jobs:
         with:
           command: test
           args: >
-            --features 'test-chattr test-setfattr test-fuse'
+            --features 'test-chattr test-setfattr test-fuse test-wtmp'

--- a/crates/rrg/Cargo.toml
+++ b/crates/rrg/Cargo.toml
@@ -49,6 +49,7 @@ action-execute_signed_command = []
 test-setfattr = []
 test-chattr = []
 test-fuse = ["dep:fuse"]
+test-wtmp = []
 
 [dependencies.ospect]
 path = "../ospect"

--- a/crates/rrg/src/action/list_utmp_users.rs
+++ b/crates/rrg/src/action/list_utmp_users.rs
@@ -200,6 +200,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "test-wtmp"), ignore)]
     fn handle_var_log_wtmp_no_dupes() {
         let args = Args {
             path: "/var/log/wtmp".into(),


### PR DESCRIPTION
Existence of `/var/log/wtmp` is not guaranteed and so it is missing in some environments. Hiding it behind a feature makes it possible to explicitly opt-into the test in environments where it does exist.