### PR TITLE
Inline unuseful `main` abstractions

### DIFF
--- a/crates/rrg/src/lib.rs
+++ b/crates/rrg/src/lib.rs
@@ -31,22 +31,3 @@ pub use startup::Startup;
 
 pub use request::{ParseRequestError, Request, RequestId};
 pub use response::{LogBuilder, Parcel, ResponseBuilder, ResponseId, Sink};
-
-/// Enters the agent's main loop and waits for messages.
-///
-/// It will poll for messages from the GRR server and should consume very few
-/// resources when idling. Once it picks a message, it dispatches it to an
-/// appropriate action handler (which should take care of sending heartbeat
-/// signals if expected to be long-running) and goes back to idling when action
-/// execution is finished.
-///
-/// This function never terminates and panics only if something went very wrong
-/// (e.g. the Fleetspeak connection has been broken). All non-critical errors
-/// are going to be handled carefully, notifying the server about the failure if
-/// appropriate.
-pub fn listen(args: &crate::args::Args) {
-    loop {
-        let request = Request::receive(args.heartbeat_rate);
-        session::FleetspeakSession::dispatch(args, request);
-    }
-}

--- a/crates/rrg/src/lib.rs
+++ b/crates/rrg/src/lib.rs
@@ -32,14 +32,6 @@ pub use startup::Startup;
 pub use request::{ParseRequestError, Request, RequestId};
 pub use response::{LogBuilder, Parcel, ResponseBuilder, ResponseId, Sink};
 
-/// Initializes the RRG subsystems.
-///
-/// This function should be called only once (at the very beginning of the
-/// process lifetime).
-pub fn init(args: &crate::args::Args) {
-    log::init(args)
-}
-
 /// Enters the agent's main loop and waits for messages.
 ///
 /// It will poll for messages from the GRR server and should consume very few

--- a/crates/rrg/src/lib.rs
+++ b/crates/rrg/src/lib.rs
@@ -17,14 +17,17 @@ mod filter;
 mod request;
 mod response;
 
-pub mod ping; // TODO(@panhania): Hide this module.
-pub mod startup; // TODO(@panhania): Hide this module.
+mod ping;
+mod startup;
 
 // TODO(@panhania): Consider moving these to a separate submodule.
 #[cfg(feature = "action-get_filesystem_timeline")]
 pub mod chunked;
 #[cfg(feature = "action-get_filesystem_timeline")]
 pub mod gzchunked;
+
+pub use ping::Ping;
+pub use startup::Startup;
 
 pub use request::{ParseRequestError, Request, RequestId};
 pub use response::{LogBuilder, Parcel, ResponseBuilder, ResponseId, Sink};

--- a/crates/rrg/src/lib.rs
+++ b/crates/rrg/src/lib.rs
@@ -55,12 +55,3 @@ pub fn listen(args: &crate::args::Args) {
         session::FleetspeakSession::dispatch(args, request);
     }
 }
-
-/// Sends a system message with startup information to the GRR server.
-///
-/// This function should be called only once at the beginning of RRG's process
-/// lifetime. It communicates to the GRR server that the agent has been started
-/// and sends some basic information like agent metadata.
-pub fn startup() {
-    startup::startup()
-}

--- a/crates/rrg/src/main.rs
+++ b/crates/rrg/src/main.rs
@@ -13,7 +13,8 @@ fn main() {
     fleetspeak::startup(env!("CARGO_PKG_VERSION"));
 
     info!("sending RRG startup information");
-    rrg::startup();
+    rrg::Parcel::new(rrg::Sink::Startup, rrg::startup::Startup::now())
+        .send_unaccounted();
 
     // TODO(@panhania): Remove once no longer needed.
     if args.ping_rate > std::time::Duration::ZERO {

--- a/crates/rrg/src/main.rs
+++ b/crates/rrg/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     fleetspeak::startup(env!("CARGO_PKG_VERSION"));
 
     info!("sending RRG startup information");
-    rrg::Parcel::new(rrg::Sink::Startup, rrg::startup::Startup::now())
+    rrg::Parcel::new(rrg::Sink::Startup, rrg::Startup::now())
         .send_unaccounted();
 
     // TODO(@panhania): Remove once no longer needed.
@@ -24,7 +24,7 @@ fn main() {
             for seq in 0.. {
                 info!("sending a ping message (seq: {seq})");
 
-                rrg::Parcel::new(rrg::Sink::Ping, rrg::ping::Ping {
+                rrg::Parcel::new(rrg::Sink::Ping, rrg::Ping {
                     sent: std::time::SystemTime::now(),
                     seq,
                 }).send_unaccounted();

--- a/crates/rrg/src/main.rs
+++ b/crates/rrg/src/main.rs
@@ -7,7 +7,7 @@ use log::info;
 
 fn main() {
     let args = rrg::args::from_env_args();
-    rrg::init(&args);
+    rrg::log::init(&args);
 
     info!("sending Fleetspeak startup information");
     fleetspeak::startup(env!("CARGO_PKG_VERSION"));

--- a/crates/rrg/src/main.rs
+++ b/crates/rrg/src/main.rs
@@ -37,5 +37,8 @@ fn main() {
     }
 
     info!("listening for messages");
-    rrg::listen(&args);
+    loop {
+        let request = rrg::Request::receive(args.heartbeat_rate);
+        rrg::session::FleetspeakSession::dispatch(&args, request);
+    }
 }

--- a/crates/rrg/src/startup.rs
+++ b/crates/rrg/src/startup.rs
@@ -3,14 +3,6 @@
 // Use of this source code is governed by an MIT-style license that can be found
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
-/// Sends a system message with startup information to the GRR server.
-pub fn startup() {
-    let startup = Startup::now();
-
-    crate::response::Parcel::new(crate::Sink::Startup, startup)
-        .send_unaccounted();
-}
-
 /// Information about the agent startup.
 pub struct Startup {
     /// Metadata about the agent that has been started.


### PR DESCRIPTION
Originally, there was an idea of using RRG more as a library (e.g. for the purpose of tests) but this was never fruitful and it is unlikely we will ever go in this direction. Thus, these extra definitions only make reading the main function harder than it needs to be.