### PR TITLE
Bump the version number to 0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Łukasz Hanuszczak <hanuszczak@google.com>"]
 edition = "2024"


### PR DESCRIPTION
This is needed because on the GRR server we want to be able to branch on endpoints having changes introduces in #123.