### PR TITLE
Bump version number to 0.0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Łukasz Hanuszczak <hanuszczak@google.com>"]
 edition = "2024"


### PR DESCRIPTION
In #128 we change the way errors are reported and this is not fully backward compatible change (the server could depend on the action failure in case file is not found), so we need a way for the server to branch depending on the error reporting style.