### PR TITLE
Add a target for Fleetspeakless execution.

### DIFF
--- a/crates/rrg/src/lib.rs
+++ b/crates/rrg/src/lib.rs
@@ -30,4 +30,4 @@ pub use ping::Ping;
 pub use startup::Startup;
 
 pub use request::{ParseRequestError, Request, RequestId};
-pub use response::{Item as ResponseItem, LogBuilder, Parcel, ResponseBuilder, ResponseId, Sink};
+pub use response::{Item, LogBuilder, Parcel, ResponseBuilder, ResponseId, Sink};


### PR DESCRIPTION
I whipped this together to have a test cycle that didn't involve GRR. It takes in a single encoded request over stdin and prints any responses to stdout.