### PR TITLE
Bump the version number to 0.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Łukasz Hanuszczak <hanuszczak@google.com>"]
 edition = "2024"


### PR DESCRIPTION
This is needed to able able to branch in the GRR server on whether system type is available in the startup record (#133).