### PR TITLE
Make `cp` in `tsk-sys` build script more robust

### DIFF
--- a/crates/tsk-sys/build.rs
+++ b/crates/tsk-sys/build.rs
@@ -21,7 +21,8 @@ fn main() {
     // scripts, which are only supposed to mutate the out directory, so this
     // copies the entire sleuthkit source into the out directory first.
     Command::new("cp")
-        .arg("-r")
+        .arg("--recursive")
+        .arg("--no-target-directory")
         .arg(sleuthkit_source_path)
         .arg(&sleuthkit_out_path)
         .status()


### PR DESCRIPTION
Without the `--no-target-directory` flag `cp` changes its behaviour depending the target folder of the same name already exists or not. Passing `--no-target-directory` (or `--target-directory` for the opposite effect) makes the behaviour more predictable.