### PR TITLE
Make `tsk::version()` test be version-independent

### DIFF
--- a/crates/tsk/src/lib.rs
+++ b/crates/tsk/src/lib.rs
@@ -493,7 +493,7 @@ mod test {
     const SMOL_NTFS_GZ: &[u8] = include_bytes!("../test_data/smol.ntfs.gz");
     #[test]
     fn test_version() {
-        assert_eq!(version(), "4.13.0");
+        assert_eq!(version().split(".").count(), 3);
     }
 
     #[test]


### PR DESCRIPTION
Internally we want to link against the common version, not vendored as submodule in this repository and depending on exact strings causes issues. Here we verify that the `tsk::version` works and returns something somewhat resembling a version string.