### PR TITLE
Bump version number to 0.0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Łukasz Hanuszczak <hanuszczak@google.com>"]
 edition = "2024"


### PR DESCRIPTION
This is to be able to branch on support for `get_file_sha256` (#151) on the GRR server.