### PR TITLE
Lower `get_file_contents` blob size limit

### DIFF
--- a/crates/rrg/src/action/get_file_contents.rs
+++ b/crates/rrg/src/action/get_file_contents.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 /// Limit on the size of individual file part blob sent to the blob sink.
-const MAX_BLOB_LEN: usize = 2 * 1024 * 1024; // 2 MiB.
+const MAX_BLOB_LEN: usize = 1 * 1024 * 1024; // 1 MiB.
 
 /// Arguments of the `get_file_contents` action.
 pub struct Args {


### PR DESCRIPTION
Fleetspeak message size [is 2 MiB][1] and so by having 2 MiB blobs, with their associated metadata, we trip over that limit. google/fleetspeak-rs#10 tracks this issue on the Fleetspeak connector library side.

[1]: https://github.com/google/fleetspeak/blob/126fd45b8732cb0998a5a93845489887daf89bd9/fleetspeak/src/client/channel/channel.go#L50