### PR TITLE
Bump version number to 0.0.7.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Łukasz Hanuszczak <hanuszczak@google.com>"]
 edition = "2024"


### PR DESCRIPTION
This is needed to be able to branch in the GRR server on the #161 fix (and disable `get_file_contents` in all other cases).