### PR TITLE
Shrink `dump_process_memory` max blob size

### DIFF
--- a/crates/rrg/src/action/dump_process_memory.rs
+++ b/crates/rrg/src/action/dump_process_memory.rs
@@ -753,7 +753,7 @@ impl crate::request::Args for Args {
     }
 }
 
-const MAX_BLOB_SIZE: u64 = 2 * (1024 * 1024);
+const MAX_BLOB_SIZE: u64 = 1024 * 1024; // 1 MiB
 
 /// Successful result of the `dump_process_memory` action.
 /// Represents a single (potentially partially) dumped


### PR DESCRIPTION
The previous limit of 2 MiB exceeded fleetspeak's message size limits.