### PR TITLE
Remove `keramics-vfs` from `rrg` dependencies

### DIFF
--- a/crates/rrg/Cargo.toml
+++ b/crates/rrg/Cargo.toml
@@ -35,7 +35,7 @@ action-get_file_metadata = []
 action-get_file_metadata-md5 = ["action-get_file_metadata", "dep:md-5"]
 action-get_file_metadata-sha1 = ["action-get_file_metadata", "dep:sha1"]
 action-get_file_metadata-sha256 = ["action-get_file_metadata", "dep:sha2"]
-action-get_file_metadata_kmx = ["dep:keramics-core", "dep:keramics-datetime", "dep:keramics-formats", "dep:keramics-types", "dep:keramics-vfs"]
+action-get_file_metadata_kmx = ["dep:keramics-core", "dep:keramics-datetime", "dep:keramics-formats", "dep:keramics-types"]
 action-get_file_contents = ["dep:sha2"]
 action-get_file_contents_kmx = ["dep:keramics-core", "dep:keramics-formats", "dep:keramics-types"]
 action-get_file_sha256 = ["dep:sha2"]
@@ -132,10 +132,6 @@ version = "0.0.0"
 optional = true
 
 [dependencies.keramics-types]
-version = "0.0.0"
-optional = true
-
-[dependencies.keramics-vfs]
 version = "0.0.0"
 optional = true
 


### PR DESCRIPTION
It was used during development but the final code does not need it.