### PR TITLE
Use non-blocking reads in `get_file_metadata`

### DIFF
--- a/crates/rrg/src/action/get_file_metadata.rs
+++ b/crates/rrg/src/action/get_file_metadata.rs
@@ -157,7 +157,19 @@ where
                     buf.capacity(),
                 };
 
-                let mut file = match std::fs::File::open(&entry.path) {
+                let mut file_open_opts = std::fs::OpenOptions::new();
+                file_open_opts.read(true);
+
+                // Some regular files can be blocking (e.g. `/proc/kmsg` on
+                // Linux) so we do only non-blocking reads to avoid process
+                // hangups.
+                #[cfg(target_family = "unix")]
+                {
+                    use std::os::unix::fs::OpenOptionsExt as _;
+                    file_open_opts.custom_flags(libc::O_NONBLOCK);
+                }
+
+                let mut file = match file_open_opts.open(&entry.path) {
                     Ok(file) => file,
                     Err(error) => {
                         log::error! {
@@ -307,7 +319,18 @@ fn digest(path: &Path, metadata: &std::fs::Metadata, args: &Args) -> Digest {
         return Digest::default();
     }
 
-    let mut file = match std::fs::File::open(path) {
+    let mut file_open_opts = std::fs::OpenOptions::new();
+    file_open_opts.read(true);
+
+    // Some regular files can be blocking (e.g. `/proc/kmsg` on Linux) so we do
+    // only non-blocking reads to avoid process hangups.
+    #[cfg(target_family = "unix")]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        file_open_opts.custom_flags(libc::O_NONBLOCK);
+    }
+
+    let mut file = match file_open_opts.open(path) {
         Ok(file) => std::io::BufReader::new(file),
         Err(error) => {
             log::error!("failed to open '{}' for digest: {error}", path.display());

--- a/crates/rrg/src/action/get_file_metadata.rs
+++ b/crates/rrg/src/action/get_file_metadata.rs
@@ -162,7 +162,8 @@ where
 
                 // Some regular files can be blocking (e.g. `/proc/kmsg` on
                 // Linux) so we do only non-blocking reads to avoid process
-                // hangups.
+                // hangups. A would-be-blocking read will result in an error
+                // and so the file will be simply skipped.
                 #[cfg(target_family = "unix")]
                 {
                     use std::os::unix::fs::OpenOptionsExt as _;
@@ -323,7 +324,8 @@ fn digest(path: &Path, metadata: &std::fs::Metadata, args: &Args) -> Digest {
     file_open_opts.read(true);
 
     // Some regular files can be blocking (e.g. `/proc/kmsg` on Linux) so we do
-    // only non-blocking reads to avoid process hangups.
+    // only non-blocking reads to avoid process hangups. A would-be-blocking
+    // read will result in an error and so the file will be simply skipped.
     #[cfg(target_family = "unix")]
     {
         use std::os::unix::fs::OpenOptionsExt as _;


### PR DESCRIPTION
No tests as apparently there is no reliable way to do it—we can create only non-blocking regular files and such are not considered for reading anyway. `/proc/kmsg` that has the issue requires root privileges to be read so that also is a no-go. Given that the code is covered anyway (it always executes), I think that is tolerable omission.