### PR TITLE
Implement abort reporting

### DIFF
--- a/crates/rrg-proto/build.rs
+++ b/crates/rrg-proto/build.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 const PROTOS: &'static [&'static str] = &[
     "../../proto/rrg.proto",
+    "../../proto/rrg/abort.proto",
     "../../proto/rrg/blob.proto",
     "../../proto/rrg/fs.proto",
     "../../proto/rrg/net.proto",

--- a/crates/rrg/src/abort.rs
+++ b/crates/rrg/src/abort.rs
@@ -56,14 +56,16 @@ impl RequestFileCreated {
     ///
     /// This should be only used if the request processing has been finished.
     pub fn remove(self) -> std::io::Result<()> {
-        // TODO(@panhania): Still attempt to delete the file even if unlock
-        // fails.
-        self.file.unlock()?;
+        // We still want to attempt to remove the file, even if unlocking it
+        // (for whatever reason) fails, so we don't immediately propagate the
+        // error but still report it at the end.
+        let result_unlock = self.file.unlock();
+
         drop(self.file);
 
         std::fs::remove_file(&self.path)?;
 
-        Ok(())
+        result_unlock
     }
 }
 

--- a/crates/rrg/src/abort.rs
+++ b/crates/rrg/src/abort.rs
@@ -1,0 +1,253 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+//! Utilities for abort reporting.
+
+/// Handle to a file with persisted request for abort recovery.
+///
+/// This is created with the [`create_request_file`] function and should be used
+/// by request processing logic.
+#[derive(Debug)]
+pub struct RequestFileCreated {
+    /// Path to the request file.
+    path: std::path::PathBuf,
+    /// Created request file (used to hold the lock).
+    file: std::fs::File,
+}
+
+/// Persists given request information at the specified path.
+///
+/// Once request processing is finished, [`RequestFileCreated::remove`] should
+/// be called to cleanup the file. If the cleanup is not called (e.g. due to
+/// panic or other unexpected abortion), future agent startup will pickup the
+/// file (with [`open_request_file`]) and report the problem to the server.
+pub fn create_request_file<P: AsRef<std::path::Path>>(
+    path: P,
+    request_id: crate::RequestId,
+) -> std::io::Result<RequestFileCreated> {
+    let path = path.as_ref();
+
+    // TODO(@panhania): We should make this file "private" (similar to what
+    // we do with filestore directories).
+    let mut file = std::fs::File::create_new(path)?;
+
+    let mut request_proto = rrg_proto::abort::Request::new();
+    request_proto.set_flow_id(request_id.flow_id());
+    request_proto.set_request_id(request_id.request_id());
+
+    use protobuf::Message as _;
+    request_proto.write_to_writer(&mut file)
+        .map_err(std::io::Error::other)?;
+
+    file.sync_all()?;
+    file.lock()?;
+
+    Ok(RequestFileCreated {
+        path: path.to_path_buf(),
+        file,
+    })
+}
+
+impl RequestFileCreated {
+
+    /// Removes the persisted request information from the filesystem.
+    ///
+    /// This should be only used if the request processing has been finished.
+    pub fn remove(self) -> std::io::Result<()> {
+        // TODO(@panhania): Still attempt to delete the file even if unlock
+        // fails.
+        self.file.unlock()?;
+        drop(self.file);
+
+        std::fs::remove_file(&self.path)?;
+
+        Ok(())
+    }
+}
+
+/// Handle to a file with persisted request for abort recovery.
+///
+/// This is created with the [`open_request_file`] function and should be used
+/// by the agent startup logic.
+#[derive(Debug)]
+pub struct RequestFileOpened {
+    /// Path the the request file.
+    path: std::path::PathBuf,
+    /// An identifier of the flow issuing the request.
+    flow_id: u64,
+    /// A server-issued identifier of the request (unique within the flow).
+    request_id: u64,
+    /// Time at which the request was received.
+    request_time: std::time::SystemTime,
+}
+
+/// Opens previously persisted (if not deleted) request information from the
+/// specified path.
+///
+/// This should be called during the agent startup to verify that no requests
+/// were abort. In that case, [`std::io::ErrorKind::NotFound`] is returned.
+/// Otherwise, the [`RequestFileOpened::abort`] should be used to send the
+/// abort information to the GRR server.
+///
+/// Once the information is sent, [`RequestFileOpened::remove`] should be used
+/// to cleanup the file. Otherwise, future agent startups will pickup the file
+/// again.
+pub fn open_request_file<P: AsRef<std::path::Path>>(
+    path: P,
+) -> std::io::Result<RequestFileOpened> {
+    let path = path.as_ref();
+
+    let mut file = std::fs::File::open(path)?;
+
+    use protobuf::Message as _;
+    let request_proto = rrg_proto::abort::Request::parse_from_reader(&mut file)
+        .map_err(|error| std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            error,
+        ))?;
+
+    let request_time = file.metadata().and_then(|metadata| metadata.modified())
+        .unwrap_or_else(|error| {
+            log::error! {
+                "could not retrieve time for '{}': {error}",
+                path.display(),
+            };
+            std::time::UNIX_EPOCH
+        });
+
+    Ok(RequestFileOpened {
+        path: path.to_path_buf(),
+        flow_id: request_proto.flow_id(),
+        request_id: request_proto.request_id(),
+        request_time,
+    })
+}
+
+impl RequestFileOpened {
+
+    /// Returns the information about the abort retrieved from the file.
+    pub fn abort(&self) -> Abort {
+        Abort {
+            flow_id: self.flow_id,
+            request_id: self.request_id,
+            request_time: self.request_time,
+            startup_time: std::time::SystemTime::now(),
+        }
+    }
+
+    /// Removes the persisted request information from the filesystem.
+    ///
+    /// This should be only used if the abort information has been sent.
+    pub fn remove(self) -> std::io::Result<()> {
+        std::fs::remove_file(&self.path)?;
+
+        Ok(())
+    }
+}
+
+/// Information about the agent abort.
+pub struct Abort {
+    /// An identifier of the flow issuing the request.
+    flow_id: u64,
+    /// A server-issued identifier of the request (unique within the flow).
+    request_id: u64,
+    /// Time at which the request was received.
+    request_time: std::time::SystemTime,
+    /// Time at which the agent started and noticed the abortion.
+    startup_time: std::time::SystemTime,
+}
+
+impl crate::response::Item for Abort {
+
+    type Proto = rrg_proto::abort::Abort;
+
+    fn into_proto(self) -> rrg_proto::abort::Abort {
+        let mut proto = rrg_proto::abort::Abort::new();
+        proto.set_flow_id(self.flow_id);
+        proto.set_request_id(self.request_id);
+        proto.set_request_time(self.request_time.into());
+        proto.set_startup_time(self.startup_time.into());
+
+        proto
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn no_abort() {
+        let tempdir = tempfile::tempdir()
+            .unwrap();
+        let request_file_path = tempdir.path().join("foo");
+
+        let request_id = crate::RequestId {
+            flow_id: rand::random(),
+            request_id: rand::random(),
+        };
+
+        let request_file_path_copy = request_file_path.clone();
+        std::thread::spawn(move || {
+            let request_file = create_request_file(request_file_path_copy, request_id)
+                .unwrap();
+
+            if false {
+                panic!();
+            }
+
+            request_file.remove()
+                .unwrap();
+        }).join().unwrap();
+
+        // The thread did not panic, so there should be no request file.
+        let error = open_request_file(&request_file_path)
+            .unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn aborted() {
+        let tempdir = tempfile::tempdir()
+            .unwrap();
+        let request_file_path = tempdir.path().join("foo");
+
+        let request_id = crate::RequestId {
+            flow_id: rand::random(),
+            request_id: rand::random(),
+        };
+
+        let request_file_path_copy = request_file_path.clone();
+        std::thread::spawn(move || {
+            let request_file = create_request_file(request_file_path_copy, request_id)
+                .unwrap();
+
+            if true {
+                panic!();
+            }
+
+            request_file.remove()
+                .unwrap();
+        }).join().unwrap_err();
+
+        // The thread panicked, so we can retrieve the request file as it should
+        // not be removed.
+        let request_file = open_request_file(&request_file_path)
+            .unwrap();
+
+        assert_eq!(request_file.flow_id, request_id.flow_id());
+        assert_eq!(request_file.request_id, request_id.request_id());
+        // We cannot use more concrete timestamps (e.g. before and after the
+        // computation thread was started) because the filesystem clock and the
+        // system time might not be in a perfect sync.
+        assert!(request_file.request_time >= std::time::UNIX_EPOCH);
+
+        request_file.remove()
+            .unwrap();
+
+        assert!(!std::fs::exists(&request_file_path).unwrap());
+    }
+}

--- a/crates/rrg/src/abort.rs
+++ b/crates/rrg/src/abort.rs
@@ -245,7 +245,7 @@ mod tests {
         // We cannot use more concrete timestamps (e.g. before and after the
         // computation thread was started) because the filesystem clock and the
         // system time might not be in a perfect sync.
-        assert!(request_file.request_time >= std::time::UNIX_EPOCH);
+        assert!(request_file.request_time > std::time::UNIX_EPOCH);
 
         request_file.remove()
             .unwrap();

--- a/crates/rrg/src/args.rs
+++ b/crates/rrg/src/args.rs
@@ -62,6 +62,13 @@ pub struct Args {
            description="whether to log to a file")]
     pub log_to_file: Option<std::path::PathBuf>,
 
+    /// Determines whether to enable request persistence (and where).
+    #[argh(option,
+           long="request-file",
+           arg_name="PATH",
+           description="whether and where to persist requests being processed")]
+    pub request_file: Option<std::path::PathBuf>,
+
     /// Determines whether to enable filestore (and where its root folder is).
     #[argh(option,
            long="filestore-dir",

--- a/crates/rrg/src/lib.rs
+++ b/crates/rrg/src/lib.rs
@@ -5,6 +5,7 @@
 
 // TODO: Hide irrelevant modules.
 
+pub mod abort;
 pub mod action;
 pub mod args;
 pub mod filestore;

--- a/crates/rrg/src/main.rs
+++ b/crates/rrg/src/main.rs
@@ -33,6 +33,44 @@ fn main() {
     rrg::Parcel::new(rrg::Sink::Startup, rrg::Startup::now())
         .send_unaccounted();
 
+    if let Some(request_file_path) = &args.request_file {
+        match rrg::abort::open_request_file(request_file_path) {
+            Ok(request_file) => {
+                info! {
+                    "request file at '{}' found, sending RRG abort information",
+                    request_file_path.display(),
+                };
+                rrg::Parcel::new(rrg::Sink::Abort, request_file.abort())
+                    .send_unaccounted();
+
+                match request_file.remove() {
+                    Ok(()) => {
+                        info! {
+                            "request file at '{}' removed",
+                            request_file_path.display(),
+                        }
+                    }
+                    Err(error) => {
+                        error! {
+                            "could not remove request file at '{}': {error}",
+                            request_file_path.display(),
+                        }
+                    }
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                // This is fine, we actually expect the file to not be there
+                // at almost all times.
+            }
+            Err(error) => {
+                error! {
+                    "could not open the request file at '{}': {error}",
+                    request_file_path.display(),
+                }
+            }
+        }
+    }
+
     // TODO(@panhania): Remove once no longer needed.
     if args.ping_rate > std::time::Duration::ZERO {
         std::thread::spawn(move || {

--- a/crates/rrg/src/request.rs
+++ b/crates/rrg/src/request.rs
@@ -163,9 +163,9 @@ impl TryFrom<rrg_proto::rrg::Action> for Action {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct RequestId {
     /// An identifier of the flow issuing the request.
-    flow_id: u64,
+    pub(crate) flow_id: u64,
     /// A server-issued identifier of the request (unique within the flow).
-    request_id: u64,
+    pub(crate) request_id: u64,
 }
 
 impl RequestId {

--- a/crates/rrg/src/response.rs
+++ b/crates/rrg/src/response.rs
@@ -249,6 +249,8 @@ impl LogBuilder {
 pub enum Sink {
     /// Collects records of agent startup.
     Startup,
+    /// Collects records of agent aborts.
+    Abort,
     /// Collects binary blobs (e.g. fragments of files).
     Blob,
     /// Collects periodic ping messages.
@@ -260,6 +262,7 @@ impl From<Sink> for rrg_proto::rrg::Sink {
     fn from(sink: Sink) -> rrg_proto::rrg::Sink {
         match sink {
             Sink::Startup => rrg_proto::rrg::Sink::STARTUP,
+            Sink::Abort => rrg_proto::rrg::Sink::ABORT,
             Sink::Blob => rrg_proto::rrg::Sink::BLOB,
             Sink::Ping => rrg_proto::rrg::Sink::PING,
         }

--- a/crates/rrg/src/session/fake.rs
+++ b/crates/rrg/src/session/fake.rs
@@ -33,6 +33,7 @@ impl FakeSession {
             verbosity: log::LevelFilter::Debug,
             log_to_stdout: false,
             log_to_file: None,
+            request_file: None,
             filestore_dir: None,
             filestore_ttl: std::time::Duration::ZERO,
         })

--- a/crates/rrg/src/session/fleetspeak.rs
+++ b/crates/rrg/src/session/fleetspeak.rs
@@ -63,6 +63,24 @@ impl<'a, 'fs> FleetspeakSession<'a, 'fs> {
 
         info!("received request '{request_id}'");
 
+        let request_file = args.request_file.as_ref()
+            .and_then(|request_file_path| {
+                match crate::abort::create_request_file(
+                    request_file_path,
+                    request_id,
+                ) {
+                    Ok(request_file) => Some(request_file),
+                    Err(error) => {
+                        error! {
+                            "could not create request file at '{}': {error}",
+                            request_file_path.display(),
+                        }
+
+                        None
+                    }
+                }
+            });
+
         // Response identifiers that GRR agents use start at 1. The server
         // assumes this to determine the number of expected messages when the
         // status message is received. Thus, we have to replicate the behaviour
@@ -132,6 +150,13 @@ impl<'a, 'fs> FleetspeakSession<'a, 'fs> {
         };
 
         status.send_unaccounted();
+
+        if let Some(request_file) = request_file {
+            match request_file.remove() {
+                Ok(()) => (),
+                Err(error) => error!("could not delete request file: {error}"),
+            }
+        }
     }
 }
 

--- a/proto/rrg.proto
+++ b/proto/rrg.proto
@@ -224,6 +224,8 @@ enum Sink {
   STARTUP = 1;
   // Accepts binary blobs (e.g. fragments of files).
   BLOB = 2;
+  // Accepts metadata about agent abort.
+  ABORT = 3;
   // Accepts periodic ping messages.
   //
   // TODO(@panhania): Remove once no longer needed.

--- a/proto/rrg/abort.proto
+++ b/proto/rrg/abort.proto
@@ -10,8 +10,8 @@ import "google/protobuf/timestamp.proto";
 
 // Subset of the request information used for abort reporting.
 //
-// This is information is persisted in a file before request processing is
-// started. The file is deleted when the processing finishes.
+// This information is persisted in a file before request processing is started.
+// The file is deleted when the processing finishes.
 //
 // When the file is present during the agent startup, it means that the request
 // processing must have been aborted (either by the crash, RRG or Fleetspeak

--- a/proto/rrg/abort.proto
+++ b/proto/rrg/abort.proto
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+syntax = "proto3";
+
+package rrg.abort;
+
+import "google/protobuf/timestamp.proto";
+
+// Subset of the request information used for abort reporting.
+//
+// This is information is persisted in a file before request processing is
+// started. The file is deleted when the processing finishes.
+//
+// When the file is present during the agent startup, it means that the request
+// processing must have been aborted (either by the crash, RRG or Fleetspeak
+// restart, system restart etc.).
+message Request {
+  // An identifier of the flow issuing the request.
+  uint64 flow_id = 1;
+
+  // A server-issued identifier of the request (unique within the flow).
+  uint64 request_id = 2;
+}
+
+// Information about the agent abort sent to the `ABORT` sink.
+message Abort {
+  // An identifier of the flow issuing the request.
+  uint64 flow_id = 1;
+
+  // A server-issued identifier of the request (unique within the flow).
+  uint64 request_id = 2;
+
+  // Time at which the request was received.
+  google.protobuf.Timestamp request_time = 3;
+
+  // Time at which the agent started and noticed the abortion.
+  google.protobuf.Timestamp startup_time = 4;
+}


### PR DESCRIPTION
This implements a mechanism similar to the one found in the old agent where we have a [`Client.transaction_log_file`](https://github.com/google/grr/blob/9f8f7974b3ba063a7e60526d4881db0c88746aa1/grr/core/grr_response_core/config/client.py#L154-L158) that persists [currently processes messages](https://github.com/google/grr/blob/9f8f7974b3ba063a7e60526d4881db0c88746aa1/grr/client/grr_response_client/client_utils_osx_linux.py#L97-L117). The file is cleared once [we are done processing](https://github.com/google/grr/blob/9f8f7974b3ba063a7e60526d4881db0c88746aa1/grr/client/grr_response_client/comms.py#L215-L216). If the agent dies mid-processing, the file is not removed and can be used to send information about the aborted operation back to the GRR server which [marks the requesting flow as failed](https://github.com/google/grr/blob/9f8f7974b3ba063a7e60526d4881db0c88746aa1/grr/server/grr_response_server/flows/general/administrative.py#L120-L127).

Currently, if RRG dies, the server never gets the response back to the action request and "hangs" forever which is not a great user experience.

In RRG we use slightly different nomenclature:

  * _Request file_ rather than _transaction log_, as I think it better captures the structure and the purpose of the file.
  * _Abort_ rather than _crash_ as the agent can die to various reasons, including scheduled Fleetspeak or system restarts.