### PR TITLE
Report timeouts in `execute_signed_command`

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -40,6 +40,8 @@ pub struct Item {
     stderr: Vec<u8>,
     /// Whether stderr is truncated.
     truncated_stderr: bool,
+    /// Whether the command reached the specified timeout before exiting.
+    timeout_reached: bool,
 }
 
 /// Executable to use for the command.
@@ -385,11 +387,14 @@ where
     });
 
     log::info!("starting '{}' (timeout: {:?})", command_path.display(), args.timeout);
+    let mut timeout_reached = false;
     loop {
         let time_elapsed = command_start_time.elapsed();
         let time_left = args.timeout.saturating_sub(time_elapsed);
 
         if time_left.is_zero() {
+            log::warn!("timeout reached; killing subprocess (pid: {})", command_process.id());
+            timeout_reached = true;
             break;
         }
 
@@ -458,6 +463,7 @@ where
         truncated_stderr: stderr.len() == MAX_STDERR_SIZE,
         stdout,
         stderr,
+        timeout_reached,
     })?;
 
     Ok(())
@@ -629,6 +635,7 @@ impl crate::response::Item for Item {
         proto.set_stderr(self.stderr);
         proto.set_stderr_truncated(self.truncated_stderr);
 
+        proto.set_timeout_reached(self.timeout_reached);
         proto
     }
 }
@@ -1392,6 +1399,7 @@ echo 'Hello, world!'
 
         use std::os::unix::process::ExitStatusExt as _;
 
+        assert!(item.timeout_reached);
         assert!(!item.exit_status.success());
         assert_eq!(item.exit_status.signal(), Some(libc::SIGKILL));
         assert_eq!(item.stderr, b"");
@@ -1432,6 +1440,7 @@ echo 'Hello, world!'
 
         use std::os::unix::process::ExitStatusExt as _;
 
+        assert!(item.timeout_reached);
         assert!(!item.exit_status.success());
         assert_eq!(item.exit_status.signal(), Some(libc::SIGKILL));
         assert_eq!(item.stderr, b"");
@@ -1467,6 +1476,7 @@ echo 'Hello, world!'
         assert_eq!(session.reply_count(), 1);
         let item = session.reply::<Item>(0);
 
+        assert!(item.timeout_reached);
         assert!(!item.exit_status.success());
         assert_eq!(item.stderr, b"");
         assert_eq!(item.stdout, b"");
@@ -1506,6 +1516,7 @@ echo 'Hello, world!'
         assert_eq!(session.reply_count(), 1);
         let item = session.reply::<Item>(0);
 
+        assert!(item.timeout_reached);
         assert!(!item.exit_status.success());
         assert_eq!(item.stderr, b"");
         assert_eq!(item.stdout, b"");

--- a/proto/rrg/action/execute_signed_command.proto
+++ b/proto/rrg/action/execute_signed_command.proto
@@ -155,5 +155,13 @@ message Result {
 
   // Set if value of `stderr` had to be truncated.
   bool stderr_truncated = 6;
+
+  // Set if the command timed out before finishing.
+  //
+  // This does not necessarily mean the command failed,
+  // as the process could have exited normally in the time
+  // between when the timeout was detected and when the process
+  // was killed.
+  bool timeout_reached = 7;
 }
 


### PR DESCRIPTION
Add a new `timed_out` field to `Result` for the `execute_signed_command` action, set to true if the subcommand exceeded the specified timeout. This is particularly useful on Windows where we didn't report any information on _how_ the process exited (like we do with signals on Unix), so a timeout would just result in an exit code of 1 and an empty stdout/stderr.