### PR TITLE
Fix error handling bug in `get_file_contents_kmx`

### DIFF
--- a/crates/rrg/src/action/get_file_contents_kmx.rs
+++ b/crates/rrg/src/action/get_file_contents_kmx.rs
@@ -199,7 +199,7 @@ where
                             ),
                         },
                     }))?;
-                    continue
+                    break
                 }
             };
             buf.truncate(len_read);


### PR DESCRIPTION
We should not spin on error but stop reading the file.