### PR TITLE
Fix gap length in pending filestore status

### DIFF
--- a/crates/rrg/src/filestore.rs
+++ b/crates/rrg/src/filestore.rs
@@ -328,7 +328,7 @@ impl Filestore {
                 std::cmp::Ordering::Equal => (),
                 std::cmp::Ordering::Less => return Ok(Status::Pending {
                         offset: part_curr.offset + part_curr.len,
-                        len: part_curr.offset + part_curr.len - part_curr.offset,
+                        len: part_next.offset - (part_curr.offset + part_curr.len),
                 }),
                 std::cmp::Ordering::Greater => {
                     return Err(std::io::Error::new(
@@ -1010,6 +1010,43 @@ mod tests {
         let foo_contents = std::fs::read(filestore.path(foo_id).unwrap())
             .unwrap();
         assert_eq!(foo_contents, b"FOOBARBAZ");
+    }
+
+    #[test]
+    fn store_pending_interior_gap() {
+        let tempdir = tempfile::tempdir()
+            .unwrap();
+
+        let filestore = Filestore::init(tempdir.path(), Duration::MAX)
+            .unwrap();
+
+        let foo_id = Id {
+            flow_id: 0xf00,
+            file_sha256: sha256(&[0x00; 20]),
+        };
+
+        filestore.store(foo_id, Part {
+            offset: 0,
+            content: vec![0x00; 3],
+            file_len: 20,
+            file_exec: false,
+        }).unwrap();
+
+        // Leaves an interior hole of `[3; 10)` between the two stored parts. The
+        // reported length must be the size of that hole (7), not the size of the
+        // preceding part (3).
+        assert_eq! {
+            filestore.store(foo_id, Part {
+                offset: 10,
+                content: vec![0x00; 3],
+                file_len: 20,
+                file_exec: false,
+            }).unwrap(),
+            Status::Pending {
+                offset: 3,
+                len: 7,
+            },
+        };
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`Filestore::store` returns `Status::Pending { offset, len }` describing a byte
range that still needs to be transferred. When the missing range is an interior
hole between two already-stored, non-adjacent parts, `len` was computed as:

```rust
len: part_curr.offset + part_curr.len - part_curr.offset,
```

which simplifies to `part_curr.len` — the length of the *preceding* part rather
than the size of the gap. `offset` was correct, and the other two `Pending`
branches (leading gap, trailing gap) were already correct.

Example: parts stored at `[0, 3)` and `[10, 13)` of a 20-byte file. The hole is
`[3, 10)` (7 bytes), but `store` returned `Pending { offset: 3, len: 3 }`.

### Fix

Compute the actual gap size:

```rust
len: part_next.offset - (part_curr.offset + part_curr.len),
```

### Testing

Added `store_pending_interior_gap`, which exercises this branch and fails before
the fix. `cargo test -p rrg --lib filestore` passes (30 tests).
