### PR TITLE
Read connection tables from target namespace

### DIFF
--- a/crates/ospect/src/net/linux/conn.rs
+++ b/crates/ospect/src/net/linux/conn.rs
@@ -12,7 +12,12 @@ pub fn tcp_v4(pid: u32) -> std::io::Result<impl Iterator<Item = std::io::Result<
     let socket_inodes = get_open_socket_inodes(pid)?;
     Ok(TcpConnections {
         pid,
-        iter: Connections::new("/proc/net/tcp", parse_tcp_v4_connection)?,
+        // We read the table through `/proc/{pid}/net` rather than `/proc/net` so
+        // that we observe it from the network namespace of the target process
+        // (e.g. a containerized one) instead of our own. The listing still
+        // contains every connection in that namespace, so we filter it down to
+        // the sockets actually owned by the process using `socket_inodes`.
+        iter: Connections::new(format!("/proc/{pid}/net/tcp"), parse_tcp_v4_connection)?,
     }
     .filter(move |conn| match conn {
         Ok(conn) => socket_inodes.contains(&conn.inode),
@@ -26,7 +31,7 @@ pub fn tcp_v6(pid: u32) -> std::io::Result<impl Iterator<Item = std::io::Result<
     let socket_inodes = get_open_socket_inodes(pid)?;
     Ok(TcpConnections {
         pid,
-        iter: Connections::new("/proc/net/tcp6", parse_tcp_v6_connection)?,
+        iter: Connections::new(format!("/proc/{pid}/net/tcp6"), parse_tcp_v6_connection)?,
     }
     .filter(move |conn| match conn {
         Ok(conn) => socket_inodes.contains(&conn.inode),
@@ -40,7 +45,7 @@ pub fn udp_v4(pid: u32) -> std::io::Result<impl Iterator<Item = std::io::Result<
     let socket_inodes = get_open_socket_inodes(pid)?;
     Ok(UdpConnections {
         pid,
-        iter: Connections::new("/proc/net/udp", parse_udp_v4_connection)?,
+        iter: Connections::new(format!("/proc/{pid}/net/udp"), parse_udp_v4_connection)?,
     }
     .filter(move |conn| match conn {
         Ok(conn) => socket_inodes.contains(&conn.inode),
@@ -54,7 +59,7 @@ pub fn udp_v6(pid: u32) -> std::io::Result<impl Iterator<Item = std::io::Result<
     let socket_inodes = get_open_socket_inodes(pid)?;
     Ok(UdpConnections {
         pid,
-        iter: Connections::new("/proc/net/udp6", parse_udp_v6_connection)?,
+        iter: Connections::new(format!("/proc/{pid}/net/udp6"), parse_udp_v6_connection)?,
     }
     .filter(move |conn| match conn {
         Ok(conn) => socket_inodes.contains(&conn.inode),


### PR DESCRIPTION
### Problem

Per-process connection listing on Linux reads a procfs connection table and
filters it by the process' open socket inodes. The table was read from the
global `/proc/net/{tcp,tcp6,udp,udp6}`, which the kernel renders in the
**caller's** network namespace. A target process in a different namespace (for
example inside a container) has none of its sockets represented there, so
`ospect::net::connections(pid)` (and the `tcp_*` / `udp_*` variants) silently
return an empty list for it.

### Fix

Read the tables via `/proc/{pid}/net/...` so they are rendered in the target
process' namespace. The inode-based filter (`get_open_socket_inodes`) is
unchanged and still narrows the namespace-wide listing down to the sockets
actually owned by `pid`, so there is no regression in attribution or
de-duplication versus the current global-table approach.

### Testing

`cargo check -p ospect --target x86_64-unknown-linux-gnu` passes. The existing
tests exercise same-namespace (self) lookups and are unaffected; cross-namespace
behaviour needs a container fixture that is not part of the suite.
