### PR TITLE
Avoid eager mtime lookup in `remove_file_if_old`

### DIFF
--- a/crates/rrg/src/fs.rs
+++ b/crates/rrg/src/fs.rs
@@ -307,7 +307,7 @@ fn _remove_file_if_old(path: &Path, ttl: Duration) -> std::io::Result<bool> {
         // Most modern systems should have creation time available but this is
         // not guaranteed and we use modification time as a fallback approxima-
         // tion.
-        .or(metadata.modified())
+        .or_else(|_| metadata.modified())
         .map_err(|error| std::io::Error::new(error.kind(), format! {
             "could not obtain file creation time: {error}",
         }))?


### PR DESCRIPTION
### Problem

In `remove_file_if_old`:

```rust
metadata.created().or(metadata.modified())
```

`Result::or` takes its alternative by value and evaluates it unconditionally, so
`metadata.modified()` is called on every invocation even when `created()`
succeeded — a wasted syscall on the cleanup path (`Filestore::init` walks every
file and part).

### Fix

Use `or_else(|_| metadata.modified())` so the fallback runs only when creation
time is unavailable. No behaviour change.

### Testing

`cargo test -p rrg --lib fs::` passes (26 tests).
