### PR TITLE
Fix reported hashed length in `get_file_sha256`

### DIFF
--- a/crates/rrg/src/action/get_file_sha256.rs
+++ b/crates/rrg/src/action/get_file_sha256.rs
@@ -47,6 +47,7 @@ where
 
     use sha2::Digest as _;
     let mut sha256 = sha2::Sha256::new();
+    let mut len = 0u64;
     loop {
         let buf = match file.fill_buf() {
             Ok(buf) if buf.is_empty() => break,
@@ -57,11 +58,9 @@ where
 
         let buf_len = buf.len();
         file.consume(buf_len);
+        len += buf_len as u64;
     }
     let sha256 = <[u8; 32]>::from(sha256.finalize());
-
-    let len = file.stream_position()
-        .map_err(crate::session::Error::action)?;
 
     session.reply(Item {
         path: args.path,


### PR DESCRIPTION
When computing the SHA-256 digest with `offset > 0`, the action reported
the hashed length via `file.stream_position()`. This returned the absolute
stream position at EOF (`offset + bytes_read`) rather than the number of
bytes actually read and hashed.

This change directly accumulates the bytes read in the hashing loop and
returns that value.
