### PR TITLE
Use `last_os_error` on `ioctl` failure

### DIFF
--- a/crates/ospect/src/fs/linux.rs
+++ b/crates/ospect/src/fs/linux.rs
@@ -50,7 +50,7 @@ pub fn flags<P>(path: P) -> std::io::Result<u32> where
     if code == 0 {
         Ok(flags as u32)
     } else {
-        Err(std::io::Error::from_raw_os_error(code))
+        Err(std::io::Error::last_os_error())
     }
 }
 


### PR DESCRIPTION
When `ioctl(..., FS_IOC_GETFLAGS, ...)` failed (returning -1), the error
was constructed with `std::io::Error::from_raw_os_error(code)`. In POSIX,
`ioctl` returns -1 on error and indicates the error reason via `errno`.
Passing -1 produced an `io::Error` with OS error -1 ("Unknown error -1")
instead of the actual OS error code.

This change uses `std::io::Error::last_os_error()` on non-zero return.
