### PR TITLE
Close enumerator on happy path when querying WMI

### DIFF
--- a/crates/wmi/src/windows.rs
+++ b/crates/wmi/src/windows.rs
@@ -286,6 +286,14 @@ impl<'com> Iterator for QueryRows<'com> {
             row.insert(name, value);
         }
 
+        // SAFETY: EndEnumeration must be called when enumeration is completed.
+        let status = unsafe {
+            (object.vtable().EndEnumeration)(object.as_raw_mut())
+        };
+        if status != windows_sys::Win32::Foundation::S_OK {
+            return Some(Err(Error::from_raw_hresult(status).into()));
+        }
+
         Some(Ok(row))
     }
 }


### PR DESCRIPTION
In `wmi::QueryRows::next`, property iteration begins with
`IWbemClassObject::BeginEnumeration` and iterates using `Next`. When
`Next` returned `WBEM_S_NO_MORE_DATA`, the loop terminated without
calling `EndEnumeration`.

Microsoft WMI COM documentation specifies that `EndEnumeration` must be
called to release internal enumeration resources before starting a new
enumeration or releasing the object.

This change adds the missing `EndEnumeration` call upon loop completion.
