### PR TITLE
Implement `Drop` for `Directory` in `tsk`.

### DIFF
--- a/crates/tsk/src/lib.rs
+++ b/crates/tsk/src/lib.rs
@@ -289,7 +289,7 @@ impl<'a> Directory<'a> {
         self.as_raw().addr
     }
     /// Returns the file structure for the directory.
-    pub fn file(&mut self) -> File<'a> {
+    pub fn file(&self) -> File<'a> {
         NonNull::new(self.as_raw().fs_file)
             .map(File::new)
             .expect("TSK_FS_DIR file is null")
@@ -302,23 +302,30 @@ impl<'a> Directory<'a> {
     /// Returns an iterator containing file entries for this directory.
     ///
     /// May return errors if the file entries fail to parse, e.g. if there is filesystem corruption.
-    pub fn iter_entries(&'a mut self) -> impl Iterator<Item = Result<File<'a>>> + 'a {
+    pub fn iter_entries<'dir>(&'dir self) -> impl Iterator<Item = Result<File<'a>>> + 'dir {
         DirectoryIterator::new(self)
     }
 }
 
-struct DirectoryIterator<'a> {
-    idx: usize,
-    dir: &'a mut Directory<'a>,
+impl Drop for Directory<'_> {
+    fn drop(&mut self) {
+        // SAFETY: Calling TSK's C API to close the directory handle.
+        unsafe { tsk_sys::tsk_fs_dir_close(self.inner.as_mut()) };
+    }
 }
 
-impl<'a> DirectoryIterator<'a> {
-    fn new(dir: &'a mut Directory<'a>) -> Self {
+struct DirectoryIterator<'dir, 'a> {
+    idx: usize,
+    dir: &'dir Directory<'a>,
+}
+
+impl<'dir, 'a> DirectoryIterator<'dir, 'a> {
+    fn new(dir: &'dir Directory<'a>) -> Self {
         Self { idx: 0, dir }
     }
 }
 
-impl<'a> Iterator for DirectoryIterator<'a> {
+impl<'dir, 'a> Iterator for DirectoryIterator<'dir, 'a> {
     type Item = Result<File<'a>>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -338,7 +345,7 @@ impl<'a> Iterator for DirectoryIterator<'a> {
     }
 }
 
-impl ExactSizeIterator for DirectoryIterator<'_> {}
+impl ExactSizeIterator for DirectoryIterator<'_, '_> {}
 
 pub struct File<'a> {
     pub(crate) inner: NonNull<tsk_sys::TSK_FS_FILE>,
@@ -515,7 +522,7 @@ mod test {
         assert_eq!(root_f.meta().unwrap().addr(), 5);
         let root_name = root_f.name().expect("no root name");
         assert_eq!(root_name, "");
-        let mut root_dir = fs.open_dir("/".as_ref()).expect("failed to open root dir");
+        let root_dir = fs.open_dir("/".as_ref()).expect("failed to open root dir");
         let root_f2 = root_dir.file();
         assert_eq!(root_f2.meta().unwrap().addr(), 5);
         let mut root_dir_entries = root_dir

--- a/crates/tsk/src/lib.rs
+++ b/crates/tsk/src/lib.rs
@@ -289,7 +289,12 @@ impl<'a> Directory<'a> {
         self.as_raw().addr
     }
     /// Returns the file structure for the directory.
-    pub fn file(&self) -> File<'a> {
+    ///
+    /// The returned [`File`] borrows from this `Directory`: it points at
+    /// `TSK_FS_DIR::fs_file`, which `tsk_fs_dir_close` releases when the
+    /// `Directory` is dropped. It therefore must not outlive the `Directory`
+    /// (hence the borrow of `self` rather than the file system lifetime `'a`).
+    pub fn file(&self) -> File<'_> {
         NonNull::new(self.as_raw().fs_file)
             .map(File::new)
             .expect("TSK_FS_DIR file is null")


### PR DESCRIPTION
`Directory` wraps a raw `TSK_FS_DIR` pointer obtained from
`tsk_fs_dir_open` or `tsk_fs_dir_open_meta`. In SleuthKit, directory
structures are dynamically allocated and must be freed with
`tsk_fs_dir_close`. Because `Directory` lacked a `Drop` implementation,
every opened directory leaked memory and underlying file handles.

This change implements `Drop for Directory<'_>` calling `tsk_fs_dir_close`
and relaxes `iter_entries`/`file` from `&mut self` to `&self` (the
underlying `tsk_fs_dir_get` takes `const TSK_FS_DIR *` and returns freshly
allocated files, so shared iteration is sound).

`tsk_fs_dir_close` also frees `TSK_FS_DIR::fs_file`, which is what
`Directory::file` hands back. Returning that `File` with the file system
lifetime `'a` let it outlive the `Directory`, so once `Directory` has a
`Drop` a pattern like

```rust
let f = { let d = fs.open_dir(p)?; d.file() };
```

becomes a use-after-free. `Directory::file` now borrows `self`, tying the
returned `File` to the `Directory` it came from.

Note: `File` itself still has no `Drop`, so files from `open_file` and
`iter_entries` continue to leak `TSK_FS_FILE`. Fixing that needs an
owned/borrowed distinction (the `walk_dir` callback and `Directory::file`
must not close their `File`) and is left for a follow-up.
