### PR TITLE
Avoid duplicate leading slashes in TSK timeline

### DIFF
--- a/crates/rrg/src/action/get_filesystem_timeline_tsk.rs
+++ b/crates/rrg/src/action/get_filesystem_timeline_tsk.rs
@@ -227,7 +227,9 @@ fn make_entry(
     let mut proto = rrg_proto::get_filesystem_timeline::Entry::default();
     if let Some(name) = file.name() {
         let mut path = Vec::from(root);
-        path.push(b'/');
+        if !path.ends_with(b"/") {
+            path.push(b'/');
+        }
         path.extend_from_slice(parent_path);
         path.append(&mut name.into_bytes());
         proto.set_path(path);


### PR DESCRIPTION
In `get_filesystem_timeline_tsk::make_entry`, paths were constructed by
unconditionally pushing `b'/'` onto `root`. When `root` is `"/"`, the
resulting paths began with `//` (e.g. `"//etc/passwd"`), causing
normalization issues downstream.

This change appends `b'/'` only if `root` does not already end with `/`.
