### PR TITLE
Fix swapped arguments in `get_file_metadata` log.

### DIFF
--- a/crates/rrg/src/action/get_file_metadata.rs
+++ b/crates/rrg/src/action/get_file_metadata.rs
@@ -145,8 +145,8 @@ where
             if entry.metadata.len() > args.max_size {
                 log::info! {
                     "size of '{}' ({}) exceeds the limit ({}), skipping",
-                    entry.metadata.len(),
                     entry.path.display(),
+                    entry.metadata.len(),
                     args.max_size,
                 };
 


### PR DESCRIPTION
In `get_file_metadata`, the log call for files exceeding the size limit
passed `entry.metadata.len()` as the first argument and
`entry.path.display()` as the second argument, printing:
"size of '<len>' (<path>) exceeds the limit (<limit>), skipping".

This change swaps the arguments to print the path first and size second.
