### PR TITLE
Fix `Display` message for `DupUnsignedEnvError`.

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -188,7 +188,7 @@ struct DupUnsignedEnvError {
 impl std::fmt::Display for DupUnsignedEnvError {
 
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(fmt, "'{}' not allowed as unsigned", self.name)
+        write!(fmt, "duplicate unsigned environment variable: '{}'", self.name)
     }
 }
 


### PR DESCRIPTION
`DupUnsignedEnvError` displayed "not allowed as unsigned", which was
identical to `NotAllowedUnsignedEnvError`.

This change updates the `Display` implementation to output
"duplicate unsigned environment variable: '<name>'".
