### PR TITLE
Retry process spawn on `ExecutableFileBusy` in `execute_signed_command`

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -281,16 +281,35 @@ where
             }
         }).collect::<crate::session::Result<Vec<_>>>()?;
 
-    let mut command_process = std::process::Command::new(&command_path)
+    let mut command = std::process::Command::new(&command_path);
+    command
         .stdin(std::process::Stdio::piped())
         .args(command_args)
         .env_clear()
         .envs(env_inherited)
         .envs(args.env)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(crate::session::Error::action)?;
+        .stderr(std::process::Stdio::piped());
+
+    // When executing files freshly written to the filestore on Linux, other
+    // threads forking concurrently can cause child processes to temporarily
+    // inherit open writable file descriptors, leading to `ETXTBSY` ("Text file
+    // busy", `ErrorKind::ExecutableFileBusy`). We retry with backoff so that
+    // the conflicting child process can complete `execve`/close `CLOEXEC` fds.
+    let mut command_process = {
+        let mut attempts = 0;
+        loop {
+            match command.spawn() {
+                Ok(process) => break process,
+                #[cfg(target_family = "unix")]
+                Err(error) if error.kind() == std::io::ErrorKind::ExecutableFileBusy && attempts < 5 => {
+                    attempts += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(error) => return Err(crate::session::Error::action(error)),
+            }
+        }
+    };
 
     let command_start_time = std::time::Instant::now();
 


### PR DESCRIPTION
When executing scripts or binaries freshly written to disk (such as files assembled from the filestore), calling `std::process::Command::spawn` on Unix can fail with `ETXTBSY` (`std::io::ErrorKind::ExecutableFileBusy`, "Text file busy"). This occurs when parallel threads fork child processes concurrently while a writable file descriptor is open, causing the child process to temporarily inherit the open file descriptor until `execve` runs or the `CLOEXEC` descriptor is closed.

This change adds a brief retry loop on `ErrorKind::ExecutableFileBusy` (up to 5 attempts with 10 ms backoff) when spawning commands in `execute_signed_command`, eliminating flaky failures during concurrent execution and multi-threaded test runs.