### PR TITLE
Improve opportunity window in `ETXTBSY` test

### DIFF
--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -1302,6 +1302,7 @@ echo 'Hello, world!'
         let occupier = std::thread::spawn(move || {
             drop(occupier_started_sender);
 
+            let mut yield_now_cycles = 1;
             loop {
                 match occupier_stop_receiver.try_recv() {
                     Err(std::sync::mpsc::TryRecvError::Disconnected) => break,
@@ -1323,15 +1324,17 @@ echo 'Hello, world!'
                 }
                 let file = file.unwrap();
 
-                for _ in 0..32 {
+                for _ in 0..yield_now_cycles {
                     std::thread::yield_now();
                 }
 
                 drop(file);
 
-                for _ in 0..32 {
+                for _ in 0..yield_now_cycles {
                     std::thread::yield_now();
                 }
+
+                yield_now_cycles *= 2;
             }
         });
 

--- a/crates/rrg/src/action/execute_signed_command.rs
+++ b/crates/rrg/src/action/execute_signed_command.rs
@@ -1328,6 +1328,10 @@ echo 'Hello, world!'
                 }
 
                 drop(file);
+
+                for _ in 0..32 {
+                    std::thread::yield_now();
+                }
             }
         });
 


### PR DESCRIPTION
Before the action thread had a very low chance of hitting the opportunity window on more capable CPUs. Thus, we add an extra window to let the action do some work.

Moreover, an exponential backoff should make it more and more probably to eventually hit it.