### PR TITLE
Fix Zizmor issues in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         run: brew install autoconf automake libtool
       - name: 'Checkout the repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: 'Setup the Rust toolchain'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
+          persist-credentials: false
       - name: 'Setup the Rust toolchain'
         run: |
           rustup update ${{ matrix.toolchain }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: 'Integrate'
 on:
   - push
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: 'CI'


### PR DESCRIPTION
Apparently there is now mandatory Zizmor run for all Google repositories and it [was tripping](https://github.com/google/rrg/actions/runs/33859610508/job/100980972422) over [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses), [`ref-version-mismatch`](https://docs.zizmor.sh/audits/#ref-version-mismatch) and [`artipacked`](https://docs.zizmor.sh/audits/#artipacked) for our CI.