### PR TITLE
Check fuzzing targets in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,8 @@ jobs:
       # TODO: Add a step that runs tests with all action features disabled.
       - name: 'Run RRG tests'
         run: cargo test --features 'test-chattr test-setfattr test-fuse test-wtmp test-libguestfs action-get_file_contents_kmx action-get_file_metadata_kmx action-get_file_sha256_kmx action-get_filesystem_timeline_tsk'
+      # We only type-check fuzzers (rather than actually running them) as part
+      # of the continuous integration because it is expensive. Still, we would
+      # like to ensure that there are no breaking changes to their code itself.
+      - name: 'Check RRG fuzzers'
+        run: cargo check --manifest-path fuzz/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,7 @@ jobs:
       # of the continuous integration because it is expensive. Still, we would
       # like to ensure that there are no breaking changes to their code itself.
       - name: 'Check RRG fuzzers'
+        # Fuzzing code assumes Linux environment and does not compile on other
+        # platforms.
+        if: ${{ runner.os == 'Linux' }}
         run: cargo check --manifest-path fuzz/Cargo.toml


### PR DESCRIPTION
Previous changes (e.g. #252, #253, #254) introduced breaking changes that did not adjust corresponding fuzzing code. With this change this should no longer happen.