### PR TITLE
Bump version number to 0.0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.12"
+version = "0.0.13"
 authors = ["Łukasz Hanuszczak <hanuszczak@google.com>"]
 edition = "2024"


### PR DESCRIPTION
This is needed to be able to branch on the server on multi-offset support in file actions (#252, #253, #254) as well as introduction of `get_file_sha256_kmx` (#255).