### PR TITLE
Fuzz memory actions

### DIFF
--- a/crates/rrg/src/action/dump_process_memory.rs
+++ b/crates/rrg/src/action/dump_process_memory.rs
@@ -898,6 +898,9 @@ where
                     continue 'outer;
                 }
                 Ok(buf) => {
+                    if buf.is_empty() {
+                        break;
+                    }
                     // `read_chunk` could have read fewer than `size` bytes
                     let size = buf.len() as u64;
                     offset += size;
@@ -1231,5 +1234,35 @@ pub mod tests {
             assert!(!item.region.permissions.execute);
             assert!(!item.region.permissions.shared);
         }
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn dump_regions_handles_empty_chunk_read() {
+        struct EmptyChunkMemory;
+
+        impl MemoryReader for EmptyChunkMemory {
+            fn read_chunk(&mut self, _offset: u64, _length: u64) -> std::io::Result<Vec<u8>> {
+                // Simulates EOF or unreadable page returning 0 bytes
+                Ok(Vec::new())
+            }
+        }
+
+        let regions = vec![MappedRegion::from_bounds(1000, 2000)];
+        let mut memory = EmptyChunkMemory;
+        let mut session = crate::session::FakeSession::new();
+        let mut limit = u64::MAX;
+
+        dump_regions(
+            &mut session,
+            regions.into_iter(),
+            &mut memory,
+            42,
+            &mut limit,
+        )
+        .unwrap();
+
+        assert_eq!(session.reply_count(), 0);
+        assert_eq!(session.parcel_count(crate::Sink::Blob), 0);
     }
 }

--- a/crates/rrg/src/action/scan_memory_yara.rs
+++ b/crates/rrg/src/action/scan_memory_yara.rs
@@ -193,7 +193,7 @@ impl From<Match> for proto::Match {
 }
 
 #[derive(Debug)]
-enum Error {
+pub enum Error {
     /// Failed to open the process' memory for reading.
     OpenProcessMemory(std::io::Error),
     /// There was an error (e.g. a timeout) when scanning memory
@@ -264,28 +264,35 @@ impl crate::response::Item for Item {
     }
 }
 
-/// Reads and scans a single region of memory, breaking it up into chunks of `chunk_size` with an overlap of
+/// Reads and scans memory `regions`, breaking each up into chunks of `chunk_size` with an overlap of
 /// `chunk_overlap`. Only returns an error if scanning failed; read errors are ignored.
-fn scan_region<M: MemoryReader>(
-    region: &MappedRegion,
+pub fn scan_regions<M: MemoryReader>(
+    regions: impl Iterator<Item = MappedRegion>,
     scanner: &mut Scanner,
     memory: &mut M,
     chunk_size: NonZeroU64,
     chunk_overlap: u64,
 ) -> Result<(), Error> {
     let chunk_size = chunk_size.get();
-    let mut offset = region.start_address();
-    while offset < region.end_address() {
-        let remaining = region.end_address() - offset;
-        let length = remaining.min(chunk_size + chunk_overlap);
-        // Any process will most likely have at least one region
-        // that cannot be read successfully, so there's no point
-        // in reporting an error to the user if that happens,
-        // just ignore it and continue.
-        if let Ok(buf) = memory.read_chunk(offset, length) {
-            scanner.scan(offset as usize, &buf).map_err(Error::Scan)?;
+    'outer: for region in regions {
+        let mut offset = region.start_address();
+        while offset < region.end_address() {
+            let remaining = region.end_address() - offset;
+            let length = remaining.min(chunk_size + chunk_overlap);
+            match memory.read_chunk(offset, length) {
+                Err(_) => {
+                    // Any process will most likely have at least one region
+                    // that cannot be read successfully, so there's no point
+                    // in reporting an error to the user if that happens,
+                    // just ignore it and continue.
+                    continue 'outer;
+                }
+                Ok(buf) => {
+                    scanner.scan(offset as usize, &buf).map_err(Error::Scan)?;
+                }
+            }
+            offset = offset.saturating_add(chunk_size);
         }
-        offset = offset.saturating_add(chunk_size);
     }
     Ok(())
 }
@@ -348,19 +355,14 @@ where
             scanner.max_matches_per_pattern(limit);
         }
 
-        if let Err(error) = regions
-            .into_iter()
-            .filter(|reg| args.filter.matches(reg))
-            .try_for_each(|region| {
-                scan_region(
-                    &region,
-                    &mut scanner,
-                    &mut memory,
-                    args.chunk_size,
-                    args.chunk_overlap,
-                )
-            })
-        {
+        let filtered_regions = regions.into_iter().filter(|reg| args.filter.matches(reg));
+        if let Err(error) = scan_regions(
+            filtered_regions,
+            &mut scanner,
+            &mut memory,
+            args.chunk_size,
+            args.chunk_overlap,
+        ) {
             session.reply(Err(ErrorItem { pid, error }))?;
             continue;
         }
@@ -443,10 +445,14 @@ mod tests {
         let mut scanner = Scanner::new(&rules);
 
         let mut memory = FakeProcessMemory { contents };
-        for region in regions {
-            scan_region(&region, &mut scanner, &mut memory, NonZeroU64::new(1000).unwrap(), 1000)
-                .expect("failed to scan region");
-        }
+        scan_regions(
+            regions.into_iter(),
+            &mut scanner,
+            &mut memory,
+            NonZeroU64::new(1000).unwrap(),
+            1000,
+        )
+        .expect("failed to scan regions");
         let results = scanner.finish().expect("failed to finish scan");
 
         let rule = results.matching_rules().next().expect("no matching rule");
@@ -487,8 +493,8 @@ mod tests {
         let mut scanner = Scanner::new(&rules);
         let region = MappedRegion::from_bounds(0, contents.len() as u64);
         let mut memory = FakeProcessMemory { contents };
-        scan_region(
-            &region,
+        scan_regions(
+            std::iter::once(region),
             &mut scanner,
             &mut memory,
             NonZeroU64::new(CHUNK_SIZE as u64).unwrap(),

--- a/crates/rrg/src/action/scan_memory_yara.rs
+++ b/crates/rrg/src/action/scan_memory_yara.rs
@@ -4,6 +4,7 @@
 // in the LICENSE file or at https://opensource.org/licenses/MIT.
 
 use crate::action::dump_process_memory::{MappedRegion, MemoryReader, RegionFilter};
+use std::num::NonZeroU64;
 use std::time::Duration;
 
 use yara_x::Compiler;
@@ -37,7 +38,7 @@ pub struct Args {
     filter: RegionFilter,
 
     /// Length of the chunks used to read large memory regions, in bytes.
-    chunk_size: u64,
+    chunk_size: NonZeroU64,
     /// Overlap across chunks, in bytes. A larger overlap decreases
     /// the chance of missing a string located across chunk boundaries
     /// that would otherwise match.
@@ -60,7 +61,7 @@ impl crate::request::Args for Args {
     type Proto = proto::Args;
 
     fn from_proto(mut proto: Self::Proto) -> Result<Self, ParseArgsError> {
-        const DEFAULT_CHUNK_SIZE: u64 = 50 * 1024 * 1024; // 50 MiB
+        const DEFAULT_CHUNK_SIZE: NonZeroU64 = NonZeroU64::new(50 * 1024 * 1024).unwrap(); // 50 MiB
         const DEFAULT_CHUNK_OVERLAP: u64 = 10 * 1024 * 1024; // 10 MiB
 
         let mut timeout: Option<Duration> = None;
@@ -100,7 +101,10 @@ impl crate::request::Args for Args {
                 skip_executable_regions: proto.skip_executable_regions,
                 skip_readonly_regions: proto.skip_readonly_regions,
             },
-            chunk_size: proto.chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE),
+            chunk_size: proto
+                .chunk_size
+                .and_then(NonZeroU64::new)
+                .unwrap_or(DEFAULT_CHUNK_SIZE),
             chunk_overlap: proto.chunk_overlap.unwrap_or(DEFAULT_CHUNK_OVERLAP),
         })
     }
@@ -266,9 +270,10 @@ fn scan_region<M: MemoryReader>(
     region: &MappedRegion,
     scanner: &mut Scanner,
     memory: &mut M,
-    chunk_size: u64,
+    chunk_size: NonZeroU64,
     chunk_overlap: u64,
 ) -> Result<(), Error> {
+    let chunk_size = chunk_size.get();
     let mut offset = region.start_address();
     while offset < region.end_address() {
         let remaining = region.end_address() - offset;
@@ -439,7 +444,7 @@ mod tests {
 
         let mut memory = FakeProcessMemory { contents };
         for region in regions {
-            scan_region(&region, &mut scanner, &mut memory, 1000, 1000)
+            scan_region(&region, &mut scanner, &mut memory, NonZeroU64::new(1000).unwrap(), 1000)
                 .expect("failed to scan region");
         }
         let results = scanner.finish().expect("failed to finish scan");
@@ -486,7 +491,7 @@ mod tests {
             &region,
             &mut scanner,
             &mut memory,
-            CHUNK_SIZE as u64,
+            NonZeroU64::new(CHUNK_SIZE as u64).unwrap(),
             CHUNK_OVERLAP as u64,
         )
         .expect("failed to scan region");
@@ -525,7 +530,7 @@ mod tests {
             // Set limit to keep unit test time reasonable
             timeout: Some(Duration::from_secs(30)),
             max_matches_per_pattern: None,
-            chunk_size: 100 * 1024 * 1024,
+            chunk_size: NonZeroU64::new(100 * 1024 * 1024).unwrap(),
             chunk_overlap: 50 * 1024 * 1024,
             filter: Default::default(),
         };
@@ -602,7 +607,7 @@ mod tests {
             // Set limit to keep unit test time reasonable
             timeout: Some(Duration::from_secs(30)),
             max_matches_per_pattern: None,
-            chunk_size: 100 * 1024 * 1024,
+            chunk_size: NonZeroU64::new(100 * 1024 * 1024).unwrap(),
             chunk_overlap: 50 * 1024 * 1024,
             filter: Default::default(),
         };
@@ -643,7 +648,7 @@ mod tests {
             ),
             timeout: Some(Duration::from_millis(500)),
             max_matches_per_pattern: None,
-            chunk_size: 10000,
+            chunk_size: NonZeroU64::new(10000).unwrap(),
             chunk_overlap: 500,
             filter: Default::default(),
         };
@@ -686,7 +691,7 @@ mod tests {
             ),
             timeout: None,
             max_matches_per_pattern: Some(5),
-            chunk_size: 10000,
+            chunk_size: NonZeroU64::new(10000).unwrap(),
             chunk_overlap: 500,
             filter: Default::default(),
         };
@@ -725,5 +730,15 @@ mod tests {
                 pattern.matches
             );
         }
+    }
+
+    #[test]
+    fn args_defaults_zero_chunk_size() {
+        use crate::request::Args as _;
+        let mut proto = proto::Args::new();
+        proto.set_signature_inline("rule dummy { condition: true }".to_string());
+        proto.set_chunk_size(0);
+        let args = Args::from_proto(proto).unwrap();
+        assert_eq!(args.chunk_size.get(), 50 * 1024 * 1024);
     }
 }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,6 +20,7 @@ log = { version = "0.4.22", features = ["std"] }
 rrg-proto = { path = "../crates/rrg-proto" }
 regex = "1"
 tempfile = "3.2"
+yara-x = { version = "1.8.1", default-features = false }
 
 [dependencies.rrg]
 path = "../crates/rrg"
@@ -46,6 +47,7 @@ features = [
     "action-query_wmi",
     "action-execute_signed_command",
     "action-dump_process_memory",
+    "action-scan_memory_yara",
 
     # kmx
     "action-get_file_contents_kmx",
@@ -89,3 +91,11 @@ path = "fuzz_targets/fuzz_action_execute_signed_command.rs"
 [[bin]]
 name = "fuzz_action_get_tcp_response"
 path = "fuzz_targets/fuzz_action_get_tcp_response.rs"
+
+[[bin]]
+name = "fuzz_action_dump_process_memory"
+path = "fuzz_targets/fuzz_action_dump_process_memory.rs"
+
+[[bin]]
+name = "fuzz_action_scan_memory_yara"
+path = "fuzz_targets/fuzz_action_scan_memory_yara.rs"

--- a/fuzz/fuzz_targets/fuzz_action_dump_process_memory.rs
+++ b/fuzz/fuzz_targets/fuzz_action_dump_process_memory.rs
@@ -1,0 +1,114 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+#![no_main]
+
+use std::path::PathBuf;
+
+use arbitrary::Arbitrary;
+use fuzz_utils::{BoundedVec, FuzzSession, MAX_FUZZ_BUFFER_SIZE, MAX_FUZZ_VEC_LEN};
+use libfuzzer_sys::fuzz_target;
+use rrg::action::dump_process_memory::{
+    dump_regions, sort_by_priority, MappedRegion, MemoryReader, Permissions, RegionFilter,
+};
+
+/// An in-memory implementation of `MemoryReader` that serves chunks from a synthetic byte slice.
+/// This completely bypasses `/proc/*/mem` and allows ultra-fast fuzzing strictly in RAM.
+struct FuzzMemory<'a> {
+    data: &'a [u8],
+}
+
+impl MemoryReader for FuzzMemory<'_> {
+    fn read_chunk(&mut self, offset: u64, length: u64) -> std::io::Result<Vec<u8>> {
+        let offset = offset as usize;
+        let length = length as usize;
+        if offset >= self.data.len() {
+            return Ok(Vec::new());
+        }
+        let end = (offset.saturating_add(length)).min(self.data.len());
+        Ok(self.data[offset..end].to_vec())
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzRegion {
+    start: u64,
+    size: u16,
+    read: bool,
+    write: bool,
+    execute: bool,
+    shared: bool,
+    private: bool,
+    has_path: bool,
+    path_str: String,
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    memory_data: BoundedVec<u8, MAX_FUZZ_BUFFER_SIZE>,
+    regions: BoundedVec<FuzzRegion, MAX_FUZZ_VEC_LEN>,
+    priority_offsets: BoundedVec<u64, MAX_FUZZ_VEC_LEN>,
+    skip_mapped_files: bool,
+    skip_shared_regions: bool,
+    skip_executable_regions: bool,
+    skip_readonly_regions: bool,
+    total_size_limit: Option<u32>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let mut mapped_regions = Vec::new();
+    for r in input.regions {
+        // Bound the address start so regions realistically overlap with memory_data
+        let start = if input.memory_data.is_empty() {
+            0
+        } else {
+            r.start % (input.memory_data.len() as u64)
+        };
+        let end = start.saturating_add(r.size as u64);
+        if start >= end {
+            continue;
+        }
+
+        let mut region = MappedRegion::from_bounds(start, end);
+        region.permissions = Permissions {
+            read: r.read,
+            write: r.write,
+            execute: r.execute,
+            shared: r.shared,
+            private: r.private,
+        };
+        if r.has_path {
+            region.path = Some(PathBuf::from(r.path_str.replace('\0', "")));
+        }
+        mapped_regions.push(region);
+    }
+
+    // Sort regions by start address as required by `sort_by_priority` and `dump_regions`
+    mapped_regions.sort_unstable_by_key(|reg| reg.start_address());
+
+    let filter = RegionFilter {
+        skip_mapped_files: input.skip_mapped_files,
+        skip_shared_regions: input.skip_shared_regions,
+        skip_executable_regions: input.skip_executable_regions,
+        skip_readonly_regions: input.skip_readonly_regions,
+    };
+
+    let filtered_regions = mapped_regions.into_iter().filter(|reg| filter.matches(reg));
+    let ordered_regions = sort_by_priority(filtered_regions, input.priority_offsets.into());
+
+    let mut session = FuzzSession::new();
+    let mut mem = FuzzMemory {
+        data: &input.memory_data,
+    };
+    let mut total_size_left = input.total_size_limit.map(|v| v as u64).unwrap_or(u64::MAX);
+
+    let _ = dump_regions(
+        &mut session,
+        ordered_regions.into_iter(),
+        &mut mem,
+        12345,
+        &mut total_size_left,
+    );
+});

--- a/fuzz/fuzz_targets/fuzz_action_scan_memory_yara.rs
+++ b/fuzz/fuzz_targets/fuzz_action_scan_memory_yara.rs
@@ -1,0 +1,138 @@
+// Copyright 2026 Google LLC
+//
+// Use of this source code is governed by an MIT-style license that can be found
+// in the LICENSE file or at https://opensource.org/licenses/MIT.
+
+#![no_main]
+
+use std::num::NonZeroU64;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use arbitrary::Arbitrary;
+use fuzz_utils::{BoundedVec, MAX_FUZZ_BUFFER_SIZE, MAX_FUZZ_VEC_LEN};
+use libfuzzer_sys::fuzz_target;
+use rrg::action::dump_process_memory::{MappedRegion, MemoryReader, Permissions, RegionFilter};
+use rrg::action::scan_memory_yara::scan_regions;
+use yara_x::Compiler;
+use yara_x::blocks::Scanner;
+
+/// In-memory MemoryReader that slices synthetic byte slices in RAM.
+/// Bypasses `/proc/*/mem` and allows fast, isolated fuzzing.
+struct FuzzMemory<'a> {
+    data: &'a [u8],
+}
+
+impl MemoryReader for FuzzMemory<'_> {
+    fn read_chunk(&mut self, offset: u64, length: u64) -> std::io::Result<Vec<u8>> {
+        let offset = offset as usize;
+        let length = length as usize;
+        if offset >= self.data.len() {
+            return Ok(Vec::new());
+        }
+        let end = (offset.saturating_add(length)).min(self.data.len());
+        Ok(self.data[offset..end].to_vec())
+    }
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzRegion {
+    start: u64,
+    size: u16,
+    read: bool,
+    write: bool,
+    execute: bool,
+    shared: bool,
+    private: bool,
+    has_path: bool,
+    path_str: String,
+}
+
+#[derive(Debug, Arbitrary)]
+struct FuzzInput {
+    rule_source: String,
+    memory_data: BoundedVec<u8, MAX_FUZZ_BUFFER_SIZE>,
+    regions: BoundedVec<FuzzRegion, MAX_FUZZ_VEC_LEN>,
+    chunk_size: u16,
+    chunk_overlap: u16,
+    max_matches_per_pattern: Option<u8>,
+    timeout_ms: Option<u16>,
+    skip_mapped_files: bool,
+    skip_shared_regions: bool,
+    skip_executable_regions: bool,
+    skip_readonly_regions: bool,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    // Compile YARA rule from arbitrary input string
+    let mut compiler = Compiler::new();
+    if compiler.add_source(input.rule_source.as_str()).is_err() {
+        return;
+    }
+    let rules = compiler.build();
+
+    let mut mapped_regions = Vec::new();
+    for r in input.regions {
+        let start = if input.memory_data.is_empty() {
+            0
+        } else {
+            r.start % (input.memory_data.len() as u64)
+        };
+        let end = start.saturating_add(r.size as u64);
+        if start >= end {
+            continue;
+        }
+
+        let mut region = MappedRegion::from_bounds(start, end);
+        region.permissions = Permissions {
+            read: r.read,
+            write: r.write,
+            execute: r.execute,
+            shared: r.shared,
+            private: r.private,
+        };
+        if r.has_path {
+            region.path = Some(PathBuf::from(r.path_str.replace('\0', "")));
+        }
+        mapped_regions.push(region);
+    }
+
+    mapped_regions.sort_unstable_by_key(|reg| reg.start_address());
+
+    let filter = RegionFilter {
+        skip_mapped_files: input.skip_mapped_files,
+        skip_shared_regions: input.skip_shared_regions,
+        skip_executable_regions: input.skip_executable_regions,
+        skip_readonly_regions: input.skip_readonly_regions,
+    };
+    let filtered_regions = mapped_regions.into_iter().filter(|reg| filter.matches(reg));
+
+    let mut mem = FuzzMemory {
+        data: &input.memory_data,
+    };
+
+    let chunk_size = NonZeroU64::new((input.chunk_size as u64).max(1)).unwrap();
+    let chunk_overlap = input.chunk_overlap as u64;
+    let timeout = input.timeout_ms.map(|t| Duration::from_millis(t as u64));
+    let max_matches = input.max_matches_per_pattern.map(|m| m as usize);
+
+    let mut scanner = Scanner::new(&rules);
+    if let Some(timeout) = timeout {
+        scanner.set_timeout(timeout);
+    }
+    if let Some(limit) = max_matches {
+        scanner.max_matches_per_pattern(limit);
+    }
+
+    if scan_regions(
+        filtered_regions,
+        &mut scanner,
+        &mut mem,
+        chunk_size,
+        chunk_overlap,
+    )
+    .is_ok()
+    {
+        let _ = scanner.finish();
+    }
+});


### PR DESCRIPTION
Add fuzz targets for process memory dumping and YARA scanning backed by in-memory mock readers to ensure fast and isolated execution. 

Resolve two infinite loop issues caused by zero-length chunk sizes in YARA scanning and empty chunk reads during memory dumping found during creating the fuzzers.

Refactor scan_regions to mirror the structure of dump_regions, making memory scanning directly testable in RAM.